### PR TITLE
Adds translations for organisation types

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -4,6 +4,10 @@
 use craft\elements\Entry;
 use craft\helpers\UrlHelper;
 
+function translate($locale, $message, $variables = array()) {
+    return Craft::t('site', $message, $variables, $locale);
+}
+
 function getFundingProgramMatrix($entry, $locale) {
     $bodyBlocks = [];
 
@@ -26,7 +30,7 @@ function getFundingProgramMatrix($entry, $locale) {
 
                     $orgTypes = [];
                     foreach ($block->organisationType as $o) {
-                        $orgTypes[] = Craft::t('site', $o->label, array(), $locale);
+                        $orgTypes[] = translate($locale, $o->label);
                     }
                     if ($orgTypes) {
                         $fundingData['organisationTypes'] = $orgTypes;
@@ -38,7 +42,7 @@ function getFundingProgramMatrix($entry, $locale) {
 
                     if ($block->area) {
                         $fundingData['area'] = [
-                            'label' => Craft::t('site', $block->area->label, array(), $locale),
+                            'label' => translate($locale, $block->area->label),
                             'value' => $block->area->value
                         ];
                     }

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -26,7 +26,7 @@ function getFundingProgramMatrix($entry, $locale) {
 
                     $orgTypes = [];
                     foreach ($block->organisationType as $o) {
-                        $orgTypes[] = $o->label;
+                        $orgTypes[] = Craft::t('site', $o->label, array(), $locale);
                     }
                     if ($orgTypes) {
                         $fundingData['organisationTypes'] = $orgTypes;

--- a/translations/cy/site.php
+++ b/translations/cy/site.php
@@ -1,9 +1,15 @@
 <?php
 
 return array(
+    // Regions
     "England" => "Lloegr",
     "Wales" => "Cymru",
     "Scotland" => "Yr Alban",
     "Northern Ireland" => "Gogledd Iwerddon",
-    "UK-wide" => "Ledled y DU"
+    "UK-wide" => "Ledled y DU",
+
+    // Organisation types
+    "Voluntary or community organisation" => "Mudiad gwirfoddol neu gymunedol",
+    "Public sector organisation" => "Mudiad sector cyhoeddus",
+    "Private sector organisation" => "Mudiad sector preifat",
 );

--- a/translations/en/site.php
+++ b/translations/en/site.php
@@ -1,9 +1,15 @@
 <?php
 
 return array(
+    // Regions
     "England" => "England",
     "Wales" => "Wales",
     "Scotland" => "Scotland",
     "Northern Ireland" => "Northern Ireland",
-    "UK-wide" => "UK-wide"
+    "UK-wide" => "UK-wide",
+
+    // Organisation types
+    "Voluntary or community organisation" => "Voluntary or community organisation",
+    "Public sector organisation" => "Public sector organisation",
+    "Private sector organisation" => "Private sector organisation",
 );


### PR DESCRIPTION
Much like the change to translate regions in https://github.com/biglotteryfund/craft-dev/pull/4 this PR translates the names of the organisation types. All other fields for funding programmes are text fields so can be translated through the CMS.

<img width="475" alt="screen shot 2017-11-02 at 12 55 02" src="https://user-images.githubusercontent.com/123386/32327059-15923534-bfcd-11e7-9ffe-1c32e3cc754b.png">
