### PR TITLE
Support optional funding size description

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -64,6 +64,10 @@ function getFundingProgramMatrix($entry, $locale) {
                         ];
                     }
 
+                    if ($block->fundingSizeDescription) {
+                        $fundingData['fundingSizeDescription'] = $block->fundingSizeDescription;
+                    }
+
                     if ($block->totalAvailable) {
                         $fundingData['totalAvailable'] = $block->totalAvailable;
                     }


### PR DESCRIPTION
Support optional funding size description. Used instead of the explicit range if provided.