### PR TITLE
Add status script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml
+.DS_Store
+.elasticbeanstalk/*
 /.env
 /.idea
 /vendor
-.DS_Store
-license.key
 # Elastic Beanstalk Files
-.elasticbeanstalk/*
-!.elasticbeanstalk/*.cfg.yml
-!.elasticbeanstalk/*.global.yml
+license.key
+web/status.json

--- a/scripts/status
+++ b/scripts/status
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+require 'json'
+
+environment, *the_rest = ARGV
+
+status = `eb status "#{environment}"`
+
+status_map = status.lines.inject({}) { |hash, line|
+    raw_key, raw_val = line.split(':')
+    key = raw_key.strip
+    val = raw_val.strip
+
+    case key
+    when "Application name"
+        hash.merge!( { "APPLICATION_NAME" => val } )
+    when "Deployed Version"
+        hash.merge!( { "DEPLOY_ID" => val } )
+    when "Updated"
+        hash.merge!( { "UPDATED_TIME" => val } )
+    when "Status"
+        hash.merge!( { "STATUS" => val } )
+    when "Health"
+        hash.merge!( { "HEALTH" => val } )
+    end
+
+    hash
+}
+
+puts JSON.pretty_generate(status_map)
+open('web/status.json', 'w') { |f|
+  f.puts JSON.pretty_generate(status_map)
+}


### PR DESCRIPTION
Adds a status script called with:

```
./scripts/status environment-name
```
Runs the `eb status` command and outputs a truncated version to `web/status.json`

Written in Ruby as that's installed on EB environments, and I didn't want to wrangle with awk/sed.

Not so useful until I can work out the best point to actually run this. Elastic beanstalk allows you define post-deploy scripts so maybe something in there.