### PR TITLE
Remove SES plugin in favour of using SMTP interface directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     "roave/security-advisories": "dev-master",
     "craftcms/element-api": "^2.5",
     "craftcms/aws-s3": "^1.0",
-    "borucreative/craft3-ses": "^1.0",
     "craftcms/redactor": "^1.0",
     "doublesecretagency/craft-cpcss": "^2.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "95fd0eda70c493c0fef4a15913b75f36",
+    "content-hash": "9a9973b837b4560de46e9faaaf8a1992",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -85,56 +85,6 @@
                 "sdk"
             ],
             "time": "2018-01-09T22:01:13+00:00"
-        },
-        {
-            "name": "borucreative/craft3-ses",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/borucreative/craft3-ses.git",
-                "reference": "5e238c83147f79cec60995f5d32c89c44f237bb2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/borucreative/craft3-ses/zipball/5e238c83147f79cec60995f5d32c89c44f237bb2",
-                "reference": "5e238c83147f79cec60995f5d32c89c44f237bb2",
-                "shasum": ""
-            },
-            "require": {
-                "jmhobbs/swiftmailer-transport-aws-ses": "~0.9"
-            },
-            "type": "craft-plugin",
-            "extra": {
-                "name": "Amazon SES",
-                "handle": "ses",
-                "schemaVersion": "1.0.0",
-                "hasSettings": false,
-                "hasCpSection": false,
-                "changelogUrl": "https://www.github.com/borucreative/craft3-ses/blob/master/CHANGELOG.md",
-                "class": "Boru\\Ses\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Boru\\Ses\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Boru Creative",
-                    "homepage": "https://www.borucreative.com"
-                }
-            ],
-            "description": "A CraftCMS v3 Mail Transport strategy using Amazon SES",
-            "keywords": [
-                "Amazon SES",
-                "craft-plugin",
-                "craftcms"
-            ],
-            "time": "2017-03-03T04:07:38+00:00"
         },
         {
             "name": "cebe/markdown",
@@ -1331,49 +1281,6 @@
                 "url"
             ],
             "time": "2017-03-20T17:10:46+00:00"
-        },
-        {
-            "name": "jmhobbs/swiftmailer-transport-aws-ses",
-            "version": "0.9.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jmhobbs/Swiftmailer-Transport--AWS-SES.git",
-                "reference": "10110a450225a19b5095e7313a5c7c4b43bba3b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jmhobbs/Swiftmailer-Transport--AWS-SES/zipball/10110a450225a19b5095e7313a5c7c4b43bba3b6",
-                "reference": "10110a450225a19b5095e7313a5c7c4b43bba3b6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.0",
-                "swiftmailer/swiftmailer": ">=4.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "": "classes/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "John Hobbs",
-                    "email": "john@velvetcache.org"
-                }
-            ],
-            "description": "Add AWS SES support to Swiftmailer",
-            "keywords": [
-                "aws",
-                "email",
-                "ses",
-                "swiftmailer"
-            ],
-            "time": "2014-11-12T23:51:28+00:00"
         },
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
Remove SES plugin as:

- The plugin no longer works with Craft RC
- The plugin is not listed in the official plugins directory
- Amazon provide a direct SMTP transport so we can avoid using this plugin completely.

Test site reconfigured to use SMTP method.