### PR TITLE
Remove legacy endpoint

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -443,33 +443,6 @@ function getFundingProgramme($locale, $slug)
     ];
 }
 
-function getLegacyPage($locale)
-{
-    normaliseCacheHeaders();
-
-    $pagePath = \Craft::$app->request->getParam('path');
-
-    return [
-        'serializer' => 'jsonApi',
-        'elementType' => Entry::class,
-        'criteria' => [
-            'site' => $locale,
-            'legacyPath' => $pagePath,
-        ],
-        'one' => true,
-        'transformer' => function (Entry $entry) use ($locale) {
-            return [
-                'id' => $entry->id,
-                'path' => $entry->uri,
-                'url' => $entry->url,
-                'title' => $entry->title,
-                'subtitle' => $entry->legacySubtitle,
-                'body' => $entry->legacyContent,
-            ];
-        },
-    ];
-}
-
 function getListing($locale)
 {
     normaliseCacheHeaders();
@@ -587,7 +560,6 @@ return [
         'api/v1/<locale:en|cy>/promoted-news' => getPromotedNews,
         'api/v1/<locale:en|cy>/funding-programmes' => getFundingProgrammes,
         'api/v1/<locale:en|cy>/funding-programme/<slug>' => getFundingProgramme,
-        'api/v1/<locale:en|cy>/legacy' => getLegacyPage,
         'api/v1/<locale:en|cy>/listing' => getListing,
         'api/v1/<locale:en|cy>/surveys' => getSurveys,
     ],


### PR DESCRIPTION
We no longer call this endpoint from the express app, so we can remove the endpoint.