### PR TITLE
Add support for Imgix images

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,14 @@
     "doublesecretagency/craft-cpcss": "^2.0",
     "verbb/field-manager": "^2.0.1",
     "verbb/super-table": "^2.0.2",
-    "biglotteryfund/preview-button": "^1.0"
+    "biglotteryfund/preview-button": "^1.0",
+    "league/uri": "^5.2",
+    "imgix/imgix-php": "^2.0"
+  },
+  "autoload" : {
+    "psr-4" : {
+      "biglotteryfund\\" : "lib/"
+    }
   },
   "config": {
     "optimize-autoloader": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b3029275fa2b03079d9f16860fdf8fc",
+    "content-hash": "136dc09d50bde8b2bc65698695ea9868",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1475,6 +1475,39 @@
             "time": "2017-03-20T17:10:46+00:00"
         },
         {
+            "name": "imgix/imgix-php",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/imgix/imgix-php.git",
+                "reference": "ae0fa928e70a3a6da97c504b309703c213ef8206"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/imgix/imgix-php/zipball/ae0fa928e70a3a6da97c504b309703c213ef8206",
+                "reference": "ae0fa928e70a3a6da97c504b309703c213ef8206",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Imgix\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "A PHP client library for generating URLs with imgix.",
+            "keywords": [
+                "imgix"
+            ],
+            "time": "2018-03-05T20:27:38+00:00"
+        },
+        {
             "name": "justinrainbow/json-schema",
             "version": "5.2.7",
             "source": {
@@ -1803,6 +1836,470 @@
             "time": "2017-04-25T14:43:14+00:00"
         },
         {
+            "name": "league/uri",
+            "version": "5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "872194ac1ca5e51fbb9e0e5ba4d27f91aa783e82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/872194ac1ca5e51fbb9e0e5ba4d27f91aa783e82",
+                "reference": "872194ac1ca5e51fbb9e0e5ba4d27f91aa783e82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "league/uri-components": "^1.5.0",
+                "league/uri-hostname-parser": "^1.0.4",
+                "league/uri-interfaces": "^1.0",
+                "league/uri-manipulations": "^1.3",
+                "league/uri-parser": "^1.3.0",
+                "league/uri-schemes": "^1.1.1",
+                "php": ">=7.0.13",
+                "psr/http-message": "^1.0"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "http://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file-uri",
+                "ftp",
+                "hostname",
+                "http",
+                "https",
+                "middleware",
+                "parse_str",
+                "parse_url",
+                "psr-7",
+                "query-string",
+                "querystring",
+                "rfc3986",
+                "rfc3987",
+                "uri",
+                "url",
+                "ws"
+            ],
+            "time": "2017-12-01T13:36:42+00:00"
+        },
+        {
+            "name": "league/uri-components",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-components.git",
+                "reference": "fc7058401f356b8cf51ed75bad37c55c0dd960e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/fc7058401f356b8cf51ed75bad37c55c0dd960e2",
+                "reference": "fc7058401f356b8cf51ed75bad37c55c0dd960e2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-fileinfo": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "league/uri-hostname-parser": "^1.1.0",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "phpstan/phpstan": "^0.9.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI components manipulation library",
+            "homepage": "http://uri.thephpleague.com",
+            "keywords": [
+                "authority",
+                "components",
+                "fragment",
+                "host",
+                "path",
+                "port",
+                "query",
+                "rfc3986",
+                "scheme",
+                "uri",
+                "url",
+                "userinfo"
+            ],
+            "time": "2018-02-16T07:44:04+00:00"
+        },
+        {
+            "name": "league/uri-hostname-parser",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-hostname-parser.git",
+                "reference": "7a6be3d06d0ed08dcb51f666aa60f3b66cd51325"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-hostname-parser/zipball/7a6be3d06d0ed08dcb51f666aa60f3b66cd51325",
+                "reference": "7a6be3d06d0ed08dcb51f666aa60f3b66cd51325",
+                "shasum": ""
+            },
+            "require": {
+                "ext-intl": "*",
+                "php": ">=7.0",
+                "psr/simple-cache": "^1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.7",
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": "^6.3"
+            },
+            "suggest": {
+                "ext-curl": "To use the bundle cURL HTTP client",
+                "psr/simple-cache-implementation": "To enable using other cache providers"
+            },
+            "bin": [
+                "bin/update-psl-icann-section"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Kendall",
+                    "homepage": "http://about.me/jeremykendall",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "homepage": "http://nyamsprod.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/phpleague/uri-hostname-parser/graphs/contributors"
+                }
+            ],
+            "description": "ICANN base hostname parsing implemented in PHP.",
+            "homepage": "https://github.com/thephphleague/uri-hostname-parser",
+            "keywords": [
+                "Public Suffix List",
+                "domain parsing",
+                "icann"
+            ],
+            "time": "2018-02-16T07:29:26+00:00"
+        },
+        {
+            "name": "league/uri-interfaces",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-interfaces.git",
+                "reference": "dcc0be58e8b35a726274249e5eee053be1a56b66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/dcc0be58e8b35a726274249e5eee053be1a56b66",
+                "reference": "dcc0be58e8b35a726274249e5eee053be1a56b66",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\Interfaces\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "Common interface for URI representation",
+            "homepage": "http://github.com/thephpleague/uri-interfaces",
+            "keywords": [
+                "rfc3986",
+                "rfc3987",
+                "uri",
+                "url"
+            ],
+            "time": "2017-01-04T08:02:42+00:00"
+        },
+        {
+            "name": "league/uri-manipulations",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-manipulations.git",
+                "reference": "7b1344490a293e2bd2a313afc6a95927cec4c2b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-manipulations/zipball/7b1344490a293e2bd2a313afc6a95927cec4c2b3",
+                "reference": "7b1344490a293e2bd2a313afc6a95927cec4c2b3",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri-components": "^1.7.0",
+                "league/uri-interfaces": "^1.0",
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "guzzlehttp/psr7": "^1.2",
+                "league/uri-schemes": "^1.0",
+                "phpunit/phpunit": "^6.0",
+                "zendframework/zend-diactoros": "1.4.0"
+            },
+            "suggest": {
+                "league/uri-schemes": "Allow manipulating URI objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "http://url.thephpleague.com",
+            "keywords": [
+                "formatter",
+                "manipulation",
+                "manipulations",
+                "middlewares",
+                "modifiers",
+                "psr-7",
+                "references",
+                "rfc3986",
+                "rfc3987",
+                "uri",
+                "url"
+            ],
+            "time": "2018-02-06T11:37:57+00:00"
+        },
+        {
+            "name": "league/uri-parser",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-parser.git",
+                "reference": "f3c99b77f0cba4446dad2eca8c57227fcda0f39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-parser/zipball/f3c99b77f0cba4446dad2eca8c57227fcda0f39b",
+                "reference": "f3c99b77f0cba4446dad2eca8c57227fcda0f39b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-intl": "*",
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "league/uri-schemes": "Allow validating and normalizing URI parsing results"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "userland URI parser RFC 3986 compliant",
+            "homepage": "https://github.com/thephpleague/uri-parser",
+            "keywords": [
+                "parse_url",
+                "parser",
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "time": "2017-12-01T11:53:01+00:00"
+        },
+        {
+            "name": "league/uri-schemes",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-schemes.git",
+                "reference": "fd2448689186bfff27a112aa21d82931f4b366c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-schemes/zipball/fd2448689186bfff27a112aa21d82931f4b366c5",
+                "reference": "fd2448689186bfff27a112aa21d82931f4b366c5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "league/uri-interfaces": "^1.0",
+                "league/uri-parser": "^1.3.0",
+                "php": ">=7.0.13",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "league/uri-manipulations": "Needed to easily manipulate URI objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI manipulation library",
+            "homepage": "http://uri.thephpleague.com",
+            "keywords": [
+                "data-uri",
+                "file",
+                "ftp",
+                "http",
+                "https",
+                "parse_url",
+                "psr-7",
+                "rfc3986",
+                "uri",
+                "url",
+                "ws",
+                "wss"
+            ],
+            "time": "2017-12-01T12:05:37+00:00"
+        },
+        {
             "name": "mikehaertl/php-shellcommand",
             "version": "1.2.5",
             "source": {
@@ -2095,6 +2592,54 @@
                 "psr-3"
             ],
             "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "roave/security-advisories",

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -1,5 +1,6 @@
 <?php
 
+use biglotteryfund\utils\EntryHelpers;
 use biglotteryfund\utils\Images;
 use craft\elements\Entry;
 
@@ -114,10 +115,8 @@ function getFundingProgramMatrix($entry, $locale)
                     $heroImage = Images::extractImage($entry->heroImage);
                     if ($heroImage) {
                         $fundingData['photo'] = Images::imgixUrl($heroImage->imageMedium->one()->url, [
-                            'fit' => 'crop',
-                            'crop' => 'faces',
                             'w' => 80,
-                            'h' => 80
+                            'h' => 80,
                         ]);
                     }
 
@@ -184,24 +183,6 @@ function getFundingProgrammeRegionsMatrix($entry, $locale)
         }
     }
     return $regions;
-}
-
-/**
- * extractCaseStudySummary
- * Extract a summary object from a case study entry
- */
-function extractCaseStudySummary($entry)
-{
-    return [
-        'id' => $entry->id,
-        'slug' => $entry->slug,
-        'title' => $entry->title,
-        'linkUrl' => $entry->caseStudyLinkUrl,
-        'trailText' => $entry->caseStudyTrailText,
-        'trailTextMore' => $entry->caseStudyTrailTextMore,
-        'grantAmount' => $entry->caseStudyGrantAmount,
-        'thumbnailUrl' => $entry->caseStudyThumbnailImage->one()->url,
-    ];
 }
 
 /**
@@ -414,9 +395,7 @@ function getFundingProgramme($locale, $slug)
                 'contentSections' => getFundingProgrammeRegionsMatrix($entry, $locale),
             ];
 
-            if ($entry->relatedCaseStudies) {
-                $data['caseStudies'] = array_map('extractCaseStudySummary', $entry->relatedCaseStudies->all());
-            }
+            $data['caseStudies'] = EntryHelpers::extractCaseStudySummaries($entry->relatedCaseStudies->all());
 
             return $data;
         },
@@ -483,9 +462,7 @@ function getListing($locale)
                 $entryData['siblings'] = $siblings;
             }
 
-            if ($entry->relatedCaseStudies) {
-                $entryData['caseStudies'] = array_map('extractCaseStudySummary', $entry->relatedCaseStudies->all());
-            }
+            $entryData['caseStudies'] = EntryHelpers::extractCaseStudySummaries($entry->relatedCaseStudies->all());
 
             return $entryData;
         },
@@ -509,7 +486,7 @@ function getCaseStudies($locale)
             'status' => 'live',
         ],
         'transformer' => function (Entry $entry) {
-            return extractCaseStudySummary($entry);
+            return EntryHelpers::extractCaseStudySummary($entry);
         },
     ];
 }

--- a/lib/EntryHelpers.php
+++ b/lib/EntryHelpers.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace biglotteryfund\utils;
+
+use craft\elements\Entry;
+use biglotteryfund\utils\Images;
+
+class EntryHelpers
+{
+    /**
+     * extractCaseStudySummary
+     * Extract a summary object from a case study entry
+     */
+    public static function extractCaseStudySummary(Entry $entry)
+    {
+        return [
+            'id' => $entry->id,
+            'slug' => $entry->slug,
+            'title' => $entry->title,
+            'linkUrl' => $entry->caseStudyLinkUrl,
+            'trailText' => $entry->caseStudyTrailText,
+            'trailTextMore' => $entry->caseStudyTrailTextMore,
+            'grantAmount' => $entry->caseStudyGrantAmount,
+            'thumbnailUrl' => Images::imgixUrl($entry->caseStudyThumbnailImage->one()->url, [
+                'w' => 600,
+                'h' => 400,
+            ]),
+        ];
+    }
+
+    /**
+     * Wrapper around `extractCaseStudySummary`
+     * for extracting an array of summaries from a list of case studies
+     */
+    public static function extractCaseStudySummaries($caseStudies)
+    {
+        return $caseStudies ? array_map(
+            'self::extractCaseStudySummary',
+            $caseStudies
+        ) : [];
+    }
+
+}

--- a/lib/Images.php
+++ b/lib/Images.php
@@ -19,7 +19,8 @@ class Images
         return $image ? $image->url : null;
     }
 
-    public static function extractHeroImage($imageField){
+    public static function extractHeroImage($imageField)
+    {
         $result = null;
         $hero = self::extractImage($imageField);
         if ($hero) {
@@ -55,7 +56,7 @@ class Images
             $builder = new UrlBuilder($imgixDomain);
             $builder->setUseHttps(true);
 
-            $defaults = array('auto' => "compress,format", 'crop' => 'faces', 'fill' => 'crop');
+            $defaults = array('auto' => "compress,format", 'crop' => 'entropy', 'fit' => 'crop');
             $params = array_replace_recursive($defaults, $options);
             return $builder->createURL($parsedUri['path'], $params);
         } else {

--- a/lib/Images.php
+++ b/lib/Images.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace biglotteryfund\utils;
+
+use Imgix\UrlBuilder;
+use League\Uri\Parser;
+
+class Images
+{
+    public static function extractImage($imageField)
+    {
+        $image = $imageField->one();
+        return $image ?? null;
+    }
+
+    public static function extractImageUrl($imageField)
+    {
+        $image = $imageField->one();
+        return $image ? $image->url : null;
+    }
+
+    public static function extractHeroImage($imageField){
+        $result = null;
+        $hero = self::extractImage($imageField);
+        if ($hero) {
+
+            $imageSmall = self::imgixUrl($hero->imageSmall->one()->url, ['w' => '644 ', 'h' => '425']);
+            $imageMedium = self::imgixUrl($hero->imageMedium->one()->url, ['w' => '1280', 'h' => '720']);
+            $imageLarge = self::imgixUrl($hero->imageLarge->one()->url, ['w' => '1373 ', 'h' => '405']);
+
+            $result = [
+                'title' => $hero->title,
+                'caption' => $hero->caption,
+                'default' => $imageMedium,
+                'small' => $imageSmall,
+                'medium' => $imageMedium,
+                'large' => $imageLarge,
+            ];
+
+            if ($hero->captionFootnote) {
+                $result['captionFootnote'] = $hero->captionFootnote;
+            }
+        }
+
+        return $result;
+    }
+
+    public static function imgixUrl($originalUrl, $options = [])
+    {
+        $imgixDomain = getenv('CUSTOM_IMGIX_DOMAIN');
+        if ($imgixDomain) {
+            $parser = new Parser();
+            $parsedUri = $parser($originalUrl);
+
+            $builder = new UrlBuilder($imgixDomain);
+            $builder->setUseHttps(true);
+
+            $defaults = array('auto' => "compress,format", 'crop' => 'faces', 'fill' => 'crop');
+            $params = array_replace_recursive($defaults, $options);
+            return $builder->createURL($parsedUri['path'], $params);
+        } else {
+            return $originalUrl;
+        }
+    }
+}

--- a/lib/Images.php
+++ b/lib/Images.php
@@ -2,6 +2,7 @@
 
 namespace biglotteryfund\utils;
 
+use Imgix\ShardStrategy;
 use Imgix\UrlBuilder;
 use League\Uri\Parser;
 
@@ -53,8 +54,9 @@ class Images
             $parser = new Parser();
             $parsedUri = $parser($originalUrl);
 
-            $builder = new UrlBuilder($imgixDomain);
-            $builder->setUseHttps(true);
+            // PHP doesn't have named parameters, so…
+            // UrlBuilder($domain, $useHttps, $signKey, $shardStrategy, $includeLibraryParam = true)
+            $builder = new UrlBuilder($imgixDomain, true, "", ShardStrategy::CRC, false);
 
             $defaults = array('auto' => "compress,format", 'crop' => 'entropy', 'fit' => 'crop');
             $params = array_replace_recursive($defaults, $options);


### PR DESCRIPTION
This PR adds basic support for cropping and optimising images through Imgix.

Only set to run if `CUSTOM_IMGIX_DOMAIN` is set to we can merge this code before launching to production to test things out.

Two main changes:

- Funding programme thumbnail images are now created on the fly, so we can get rid of the custom thumbnail image field.
- Optimises hero images. Best case I could find was https://www.biglotteryfund.org.uk/funding/programmes/awards-from-the-uk-portfolio which is down from  **399KB** to **57KB** for the same quality images. Serves a compressed WebP image where available, otherwise falls back to jpg.

I've also made a start extracting helper methods out into separate classes so that `element-api.php` doesn't become a never ending file.

Rough, non-scientific, before and after render timeline from Lighthouse:

**Before**

![image](https://user-images.githubusercontent.com/123386/37218492-7f9befa2-23b8-11e8-8096-be316566b944.png)

**After**
![image](https://user-images.githubusercontent.com/123386/37218473-74026824-23b8-11e8-8305-ad879f3b65a2.png)
