### PR TITLE
Replace images in content with imgix urls

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -170,7 +170,7 @@ function getFundingProgrammeRegionsMatrix($entry, $locale)
                 case 'programmeRegion':
                     $region = [
                         'title' => $block->programmeRegionTitle,
-                        'body' => $block->programmeRegionBody,
+                        'body' => Images::replaceInlineImgixUrls($block->programmeRegionBody),
                     ];
                     array_push($regions, $region);
                     break;

--- a/lib/EntryHelpers.php
+++ b/lib/EntryHelpers.php
@@ -120,5 +120,4 @@ class EntryHelpers
             $caseStudies
         ) : [];
     }
-
 }

--- a/lib/Images.php
+++ b/lib/Images.php
@@ -58,11 +58,57 @@ class Images
             // UrlBuilder($domain, $useHttps, $signKey, $shardStrategy, $includeLibraryParam = true)
             $builder = new UrlBuilder($imgixDomain, true, "", ShardStrategy::CRC, false);
 
-            $defaults = array('auto' => "compress,format", 'crop' => 'entropy', 'fit' => 'crop');
+            $defaults = array('auto' => "compress,format");
+
+            if (array_key_exists('w', $options)) {
+                $defaults['crop'] = 'entropy';
+                $defaults['fit'] = 'crop';
+            }
+
             $params = array_replace_recursive($defaults, $options);
+
             return $builder->createURL($parsedUri['path'], $params);
         } else {
             return $originalUrl;
+        }
+    }
+
+    private static function innerHTML($node)
+    {
+        return implode(
+            array_map(
+                [$node->ownerDocument, "saveHTML"],
+                iterator_to_array($node->childNodes)
+            )
+        );
+    }
+
+    public static function replaceInlineImgixUrls($content)
+    {
+        $imgixDomain = getenv('CUSTOM_IMGIX_DOMAIN');
+        if ($imgixDomain) {
+            $document = new DOMDocument();
+            // https://stackoverflow.com/questions/6090667/php-domdocument-errors-warnings-on-html5-tags#6090728
+            libxml_use_internal_errors(true);
+            $document->loadHTML(mb_convert_encoding($content->getParsedContent(), 'HTML-ENTITIES', 'UTF-8'));
+            libxml_clear_errors();
+
+            $tags = $document->getElementsByTagName('img');
+            foreach ($tags as $tag) {
+                $originalSrc = $tag->getAttribute('src');
+                if (preg_match("/media\.biglotteryfund\.org\.uk/", $originalSrc)) {
+                    $newSrc = self::imgixUrl($originalSrc, [
+                        'fit' => 'crop',
+                        'crop' => 'entropy',
+                        'max-w' => 2000,
+                    ]);
+                    $tag->setAttribute('src', $newSrc);
+                }
+            }
+
+            return self::innerHTML($document->getElementsByTagName('body')[0]);
+        } else {
+            return $content;
         }
     }
 }


### PR DESCRIPTION
Proof of concept PR to replace image urls in content areas with optimised imgix urls. Not sure if this is the best way to go or if I should try and update the asset profile in craft to use the imgix domain directly with some defaults set (assuming that's possible). Thoughts welcome.