### PR TITLE
Add a new homepage API endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "verbb/super-table": "^2.0.2",
     "biglotteryfund/preview-button": "^1.0",
     "league/uri": "^5.2",
-    "imgix/imgix-php": "^2.1"
+    "imgix/imgix-php": "^2.1",
+    "verbb/expanded-singles": "^1.0"
   },
   "autoload" : {
     "psr-4" : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc124f924a9c2a38079b75e7caf2dd9f",
+    "content-hash": "9f1647e30317c72aa492c5290f303d9b",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -3400,6 +3400,60 @@
                 "templating"
             ],
             "time": "2018-03-03T16:23:01+00:00"
+        },
+        {
+            "name": "verbb/expanded-singles",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/verbb/expanded-singles.git",
+                "reference": "699d66d3ce1c7ce4244bd2173b1c21913d6df0c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/verbb/expanded-singles/zipball/699d66d3ce1c7ce4244bd2173b1c21913d6df0c1",
+                "reference": "699d66d3ce1c7ce4244bd2173b1c21913d6df0c1",
+                "shasum": ""
+            },
+            "require": {
+                "craftcms/cms": "^3.0.0-RC1"
+            },
+            "type": "craft-plugin",
+            "extra": {
+                "name": "Expanded Singles",
+                "handle": "expanded-singles",
+                "description": "Alters the Entries Index sidebar to list all Singles, rather than grouping them under a 'Singles' link.",
+                "schemaVersion": "1.0.0",
+                "hasCpSettings": true,
+                "hasCpSection": false,
+                "documentationUrl": "https://github.com/verbb/expanded-singles",
+                "changelogUrl": "https://raw.githubusercontent.com/verbb/expanded-singles/craft-3/CHANGELOG.md",
+                "class": "verbb\\expandedsingles\\ExpandedSingles"
+            },
+            "autoload": {
+                "psr-4": {
+                    "verbb\\expandedsingles\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Verbb",
+                    "homepage": "https://verbb.io"
+                }
+            ],
+            "description": "A simple plugin for Craft CMS that alters the Entries Index sidebar to list all Singles, rather than grouping them under a 'Singles' link.",
+            "keywords": [
+                "Craft",
+                "cms",
+                "craft-plugin",
+                "craftcms",
+                "expanded singles"
+            ],
+            "time": "2018-02-20T10:35:41+00:00"
         },
         {
             "name": "verbb/field-manager",

--- a/lib/EntryHelpers.php
+++ b/lib/EntryHelpers.php
@@ -88,6 +88,42 @@ class EntryHelpers
         ];
     }
 
+    public static function queryPromotedNews()
+    {
+        $newsQuery = Entry::find();
+        return \Craft::configure($newsQuery, [
+            'section' => 'news',
+            'limit' => 3,
+            'articlePromoted' => true,
+        ]);
+    }
+
+    /**
+     * extractNewsSummary
+     * Extract a summary object from a news entry
+     */
+    public static function extractNewsSummary(Entry $entry)
+    {
+        return [
+            'id' => $entry->id,
+            'title' => $entry->articleTitle,
+            'summary' => $entry->articleSummary,
+            'link' => $entry->articleLink,
+        ];
+    }
+
+    /**
+     * Wrapper around `extractNewsSummary`
+     * for extracting an array of summaries from a list of news articles
+     */
+    public static function extractNewsSummaries($newsArticles)
+    {
+        return $newsArticles ? array_map(
+            'self::extractNewsSummary',
+            $newsArticles
+        ) : [];
+    }
+
     /**
      * extractCaseStudySummary
      * Extract a summary object from a case study entry

--- a/lib/Images.php
+++ b/lib/Images.php
@@ -46,6 +46,39 @@ class Images
         return $result;
     }
 
+    public static function extractHomepageHeroImage($hero)
+    {
+        $imageSmall = self::imgixUrl($hero->imageSmall->one()->url, ['w' => '644', 'h' => '573']);
+        $imageMedium = self::imgixUrl($hero->imageMedium->one()->url, ['w' => '1280', 'h' => '720']);
+        $imageLarge = self::imgixUrl($hero->imageLarge->one()->url, ['w' => '1373', 'h' => '503']);
+
+        $result = [
+            'caption' => $hero->caption,
+            'default' => $imageMedium,
+            'small' => $imageSmall,
+            'medium' => $imageMedium,
+            'large' => $imageLarge,
+        ];
+
+        if ($hero->captionFootnote) {
+            $result['captionFootnote'] = $hero->captionFootnote;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Wrapper around `extractHomepageHeroImage`
+     * for extracting an array of summaries from a list of hero images
+     */
+    public static function extractHomepageHeroImages($homepageHeroImages)
+    {
+        return array_map(
+            'self::extractHomepageHeroImage',
+            $homepageHeroImages
+        );
+    }
+
     public static function imgixUrl($originalUrl, $options = [])
     {
         $imgixDomain = getenv('CUSTOM_IMGIX_DOMAIN');


### PR DESCRIPTION
Adds a new homepage API endpoint which allows homepage images to be managed via the CMS. They change with a reasonable enough frequency that this seems worthwhile.

Also aggregates the latest news into this same endpoint so the homepage can make a single request.

![image](https://user-images.githubusercontent.com/123386/37476320-c7a458f8-286c-11e8-9802-ed9c8cce13ea.png)
