### PR TITLE
Add Craft license

### DIFF
--- a/.ebextensions/craftlicense.config
+++ b/.ebextensions/craftlicense.config
@@ -12,9 +12,12 @@ Resources:
               DefaultValue: "aws-elasticbeanstalk-ec2-role"
 files:
   # Craft license file
-  /var/app/current/config/license.key:
+  /etc/blf/config/license.key:
     mode: "000644"
     owner: webapp
     group: webapp
     authentication: "S3Auth"
     source: https://s3-eu-west-1.amazonaws.com/blf-craft-license/license.key
+container_commands:
+  copylicense:
+    command: "mv /etc/blf/config/license.key config/license.key"

--- a/.ebextensions/craftlicense.config
+++ b/.ebextensions/craftlicense.config
@@ -1,0 +1,20 @@
+Resources:
+  AWSEBAutoScalingGroup:
+    Metadata:
+      AWS::CloudFormation::Authentication:
+        S3Auth:
+          type: "s3"
+          buckets: ["blf-craft-license"]
+          roleName: 
+            "Fn::GetOptionSetting": 
+              Namespace: "aws:autoscaling:launchconfiguration"
+              OptionName: "IamInstanceProfile"
+              DefaultValue: "aws-elasticbeanstalk-ec2-role"
+files:
+  # Craft license file
+  /var/app/current/config/license.key:
+    mode: "000644"
+    owner: webapp
+    group: webapp
+    authentication: "S3Auth"
+    source: https://s3-eu-west-1.amazonaws.com/blf-craft-license/license.key


### PR DESCRIPTION
This adds an Elastic Beanstalk script which fetches the Craft license key from S3, stores it in temporary folder (as the scope of the `files` script runs before the app is properly deployed), then when the app is ready to make live (the `container_commands` list), the license is copied to the correct place (eg. Craft's `/config` dir).

I've verified this is working on a test environment – I also think merging it shouldn't cause us issues as the Test CMS is already flagged as a non-live domain by Craft. Same should go for local environments too.