### PR TITLE
Boost upload limit to 10MB (from default 2MB) for files

### DIFF
--- a/.ebextensions/php.config
+++ b/.ebextensions/php.config
@@ -1,0 +1,8 @@
+files:
+  "/etc/php.d/uploads.ini" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+        upload_max_filesize = 10M
+        post_max_size = 10M


### PR DESCRIPTION
One of the PDF documents currently in the main app's `/files` directory is slightly larger than PHP's default 2mb limit. This PR should increase it.