### PR TITLE
Add some basic data/stat endpoints

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -685,6 +685,61 @@ function getBlogpostsBySlug($locale, $slug)
     ];
 }
 
+function getStatBlocks($locale)
+{
+    normaliseCacheHeaders();
+
+    return [
+        'serializer' => 'jsonApi',
+        'elementType' => Entry::class,
+        'criteria' => [
+            'section' => 'statBlock',
+            'site' => $locale,
+        ],
+        'transformer' => function (Entry $entry) {
+            $data = [
+                'id' => $entry->id,
+                'title' => $entry->title,
+                'value' => $entry->statValue,
+                'showNumberBeforeTitle' => $entry->showNumberBeforeTitle
+            ];
+            if ($entry->suffix) {
+                $data['suffix'] = $entry->suffix;
+            }
+            if ($entry->prefix) {
+                $data['prefix'] = $entry->prefix;
+            }
+            return $data;
+        },
+    ];
+}
+
+function getStatRegions($locale)
+{
+    normaliseCacheHeaders();
+
+    return [
+        'serializer' => 'jsonApi',
+        'elementType' => Category::class,
+        'criteria' => [
+            'group' => 'region',
+            'site' => $locale,
+        ],
+        'transformer' => function (Category $category) {
+            $data = [
+                'id' => $category->id,
+                'slug' => $category->slug,
+                'title' => $category->title,
+                'beneficiaries' => $category->beneficiaries,
+                'population' => $category->population,
+                'totalAwarded' => $category->totalAwarded,
+            ];
+
+            return $data;
+        },
+    ];
+}
+
 return [
     'endpoints' => [
         'api/v1/<locale:en|cy>/case-studies' => getCaseStudies,
@@ -703,6 +758,8 @@ return [
         'api/v1/<locale:en|cy>/blog/tags/<tag:{slug}>' => getBlogpostsByTag,
         'api/v1/<locale:en|cy>/blog/<categorySlug:{slug}>' => getBlogpostsByCategory,
         'api/v1/<locale:en|cy>/blog/<categorySlug:{slug}>/<subCategorySlug:{slug}>' => getBlogpostsByCategory,
+        'api/v1/<locale:en|cy>/stat-blocks/' => getStatBlocks,
+        'api/v1/<locale:en|cy>/stat-regions/' => getStatRegions,
         'api/v1/list-routes' => getRoutes,
     ],
 ];


### PR DESCRIPTION
This is to aid migration of https://www.biglotteryfund.org.uk/data – stores the stats in the CMS:

## Regions (eg. the map):
![image](https://user-images.githubusercontent.com/394376/39804427-e4dfa416-536b-11e8-9140-c135bb2ebc70.png)

I've made these categories rather than entries as I thought at one stage we might want to later associate these regions with things (eg. a dropdown field on an entry so we can associate news/programmes with a region). Could equally be a section, though.

## Stat blocks (eg. the big numbers at the top):
![image](https://user-images.githubusercontent.com/394376/39804463-f54d693c-536b-11e8-8ca1-a4b03f2413e9.png)

