### PR TITLE
Add concept of pull quote type in contentSegments

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -90,16 +90,41 @@ function parseSegmentMatrix($entry, $locale)
     $segments = [];
     if ($entry->contentSegment) {
         foreach ($entry->contentSegment->all() as $block) {
-            $segment = [];
-            $segment['title'] = $block->segmentTitle;
-            $segment['content'] = $block->segmentContent;
+            switch ($block->type->handle) {
+                case 'segment':
+                    $data = [
+                        'type' => $block->type->handle,
+                        'title' => $block->segmentTitle,
+                        'content' => $block->segmentContent,
+                        'anchor' => $block->anchor
+                    ];
 
-            $segmentImage = $block->segmentImage->one();
-            if ($segmentImage) {
-                $segment['photo'] = $segmentImage->url;
+                    $image = $block->segmentImage->one();
+                    if ($image) {
+                        $data['photo'] = $segmentImage->url;
+                    }
+
+                    array_push($segments, $data);
+
+                    break;
+                case 'pullQuote':
+                    $data = [
+                        'type' => $block->type->handle,
+                        'quoteText' => $block->quoteText,
+                        'linkText' => $block->linkText,
+                        'linkUrl' => $block->linkUrl
+                    ];
+
+                    $quoteImage = $block->quoteImage->one();
+                    if ($quoteImage) {
+                        $data['quoteImage'] = $quoteImage->url;
+                        $data['quoteImageCaption'] = $block->quoteImageCaption;
+                    }
+
+                    array_push($segments, $data);
+
+                    break;
             }
-
-            array_push($segments, $segment);
         }
     }
     return $segments;


### PR DESCRIPTION
Adds the concept of pull quotes as an additional content type in the `contentSegments` matrix field. Allows for alternating between content segments and pull quotes.

Used for the about page which uses the same content model as information pages. We need to give decide if it makes sense to model centrally like this as general information pages currently don't support pull quotes (although they could).

<img width="614" alt="screen shot 2018-05-16 at 15 57 50" src="https://user-images.githubusercontent.com/123386/40125146-1a15115a-5922-11e8-9246-45ba9d859c21.png">

<img width="552" alt="screen shot 2018-05-16 at 16 01 11" src="https://user-images.githubusercontent.com/123386/40125245-607849a0-5922-11e8-9205-f00f0a9bd712.png">

Also adds an `anchor` field to allow explicitly naming a content segment to anchor to, rather than relying on brittle generated IDs.