### PR TITLE
Pass the locale around when requesting homepage news

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -266,7 +266,7 @@ function getHomepage($locale)
         ],
         'one' => true,
         'transformer' => function (Entry $entry) use ($locale) {
-            $newsQuery = EntryHelpers::queryPromotedNews();
+            $newsQuery = EntryHelpers::queryPromotedNews($locale);
 
             $data = [
                 'id' => $entry->id,
@@ -667,6 +667,7 @@ function getBlogpostsByAuthor($locale, $author)
                 'targetElement' => $activeAuthor,
                 'field' => 'authors',
             ],
+
         ],
         'meta' => [
             'pageType' => 'authors',

--- a/lib/EntryHelpers.php
+++ b/lib/EntryHelpers.php
@@ -170,13 +170,14 @@ class EntryHelpers
         return $parts;
     }
 
-    public static function queryPromotedNews()
+    public static function queryPromotedNews($locale)
     {
         $newsQuery = Entry::find();
         return \Craft::configure($newsQuery, [
             'section' => 'news',
             'limit' => 3,
             'articlePromoted' => true,
+            'site' => $locale,
         ]);
     }
 


### PR DESCRIPTION
Welsh homepage is displaying English news: https://www.biglotteryfund.org.uk/welsh
![image](https://user-images.githubusercontent.com/394376/40715081-60cd3e94-63fc-11e8-8117-337cccb28083.png)

This fix passes the `$locale` through so the news is in the correct language.