### PR TITLE
Refactor draft / version behaviour to allow for drafts of unpublished pages

### DIFF
--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -1,0 +1,44 @@
+<?php
+namespace biglotteryfund\utils;
+
+use craft\elements\Entry;
+use League\Fractal\TransformerAbstract;
+
+class FundingProgrammeTransformer extends TransformerAbstract
+{
+    public function __construct($locale, $slug)
+    {
+        $this->locale = $locale;
+        $this->slug = $slug;
+    }
+
+    public function transform(Entry $entry)
+    {
+        VersionHelpers::checkValid($entry, "/funding/programmes/$this->slug", $this->locale);
+
+        $data = [
+            'id' => $entry->id,
+            'availableLanguages' => EntryHelpers::getAvailableLanguages($entry->id, $this->locale),
+            'status' => VersionHelpers::getNormalisedStatus($entry),
+            'dateUpdated' => $entry->dateUpdated,
+            'title' => $entry->title,
+            'url' => $entry->url,
+            'path' => $entry->uri,
+            'hero' => Images::extractHeroImage($entry->heroImage),
+            'summary' => getFundingProgramMatrix($entry, $this->locale),
+            'intro' => $entry->programmeIntro,
+            'contentSections' => array_map(function ($block) {
+                return [
+                    'title' => $block->programmeRegionTitle,
+                    'body' => $block->programmeRegionBody,
+                ];
+            }, $entry->programmeRegions->all()),
+        ];
+
+        if ($entry->relatedCaseStudies) {
+            $data['caseStudies'] = EntryHelpers::extractCaseStudySummaries($entry->relatedCaseStudies->all());
+        }
+
+        return $data;
+    }
+}

--- a/lib/VersionHelpers.php
+++ b/lib/VersionHelpers.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace biglotteryfund\utils;
+
+use craft;
+use craft\elements\Entry;
+use League\Fractal\TransformerAbstract;
+use League\Uri\Parser;
+
+class VersionHelpers
+{
+    public static function checkValid(Entry $entry, String $expectedUri, String $expectedLocale)
+    {
+        // Need to parse the `url` as draft entries do not yet have a `uri` property. Craft bug?
+        $parser = new Parser();
+        $parsedUrl = $parser($entry->url);
+
+        $isValid = (
+            $parsedUrl['path'] === $expectedUri &&
+            $entry->getSite()->handle === $expectedLocale
+        );
+
+        if ($isValid === false) {
+            throw new \yii\web\ForbiddenHttpException('Forbidden');
+        }
+    }
+
+    public static function getNormalisedStatus(Entry $entry)
+    {
+        $class = $entry->className();
+        if ($class === 'craft\\models\\EntryDraft') {
+            return 'draft';
+        } else if ($class === 'craft\\models\\EntryVersion') {
+            return 'version';
+        } else {
+            return $entry->status;
+        }
+    }
+
+    public static function withDraftOrVersion(TransformerAbstract $transformer, $criteria)
+    {
+        $draftId = Craft::$app->request->getQueryParam('draft');
+        $versionId = Craft::$app->request->getQueryParam('version');
+
+        if ($draftId || $versionId) {
+            $draftOrVersion = [
+                'serializer' => 'jsonApi',
+                'class' => craft\elementapi\resources\EntryResource::class,
+                'one' => true,
+                'transformer' => $transformer,
+            ];
+
+            if ($draftId) {
+                $draftOrVersion['draftId'] = $draftId;
+            }
+
+            if ($versionId) {
+                $draftOrVersion['versionId'] = $versionId;
+            }
+
+            return $draftOrVersion;
+        } else {
+            $elementQuery = [
+                'serializer' => 'jsonApi',
+                'class' => craft\elementapi\resources\EntryResource::class,
+                'criteria' => $criteria,
+                'one' => true,
+                'transformer' => $transformer,
+            ];
+
+            return $elementQuery;
+        }
+    }
+}


### PR DESCRIPTION
Refactor draft / version behaviour to allow for drafts of unpublished pages. Covers the use case of a new page being created which only has a draft (i.e. for previewing pages before publishing).

Uses the technique outlined here: https://github.com/craftcms/element-api#entry-drafts-and-versions

Main limitation is that this technique fetches the matching draft regardless of criteria (e.g. limited to a certain section) so we have to add our own guard later on.

Limiting the scope of this to funding programmes for now.