### PR TITLE
Allow disabled entries when previewing

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -345,6 +345,21 @@ function getFundingProgramme($locale, $slug)
 
     $section = 'fundingProgrammes';
 
+    /**
+     * Include expired entries
+     * Allows expiry date to be used to drop items of the listing,
+     * but still maintain the details page for historical purposes
+     */
+    $statuses = ['live', 'expired'];
+
+    /**
+     * Allow disabled versions when requesting drafts
+     * to support previews of brand new or disabled pages.
+     */
+    if (EntryHelpers::isDraftOrVersion()) {
+        $statuses[] = 'disabled';
+    }
+
     return [
         'serializer' => 'jsonApi',
         'elementType' => Entry::class,
@@ -352,12 +367,7 @@ function getFundingProgramme($locale, $slug)
             'site' => $locale,
             'section' => $section,
             'slug' => $slug,
-            /**
-             * Include expired entries
-             * Allows expiry date to be used to drop items of the listing,
-             * but still maintain the details page for historical purposes
-             */
-            'status' => ['live', 'expired'],
+            'status' => $statuses,
         ],
         'one' => true,
         'transformer' => function (Entry $entry) use ($locale, $section, $slug) {

--- a/lib/EntryHelpers.php
+++ b/lib/EntryHelpers.php
@@ -35,6 +35,14 @@ class EntryHelpers
         return $locale === 'cy' ? "/welsh/$uri" : "/$uri";
     }
 
+    public static function isDraftOrVersion()
+    {
+        $isDraft = \Craft::$app->request->getParam('draft');
+        $isVersion = \Craft::$app->request->getParam('version');
+
+        return $isDraft || $isVersion;
+    }
+
     /**
      * getDraftOrVersionOfEntry
      * Looks up an old version or draft of an entry


### PR DESCRIPTION
It turns out there is a simpler way of approaching this https://github.com/biglotteryfund/craft-dev/pull/78 without the need for a big refactor and with fewer caveats.

When requested a draft or version we allow the 'disabled' status. This allows for new an unpublished entry to be previewed where the main entry is disabled and then a draft is created to preview the page.