### PR TITLE
Use zero precision for estimated filesize

### DIFF
--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -9,12 +9,12 @@ class ContentHelpers
 {
     public static function getCommonDetailFields(Entry $entry, $locale)
     {
-
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
 
         return [
             'id' => $entry->id,
             'status' => $status,
+            'postDate' => $entry->postDate,
             'dateCreated' => $entry->dateCreated,
             'dateUpdated' => $entry->dateUpdated,
             'availableLanguages' => EntryHelpers::getAvailableLanguages($entry->id, $locale),

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -37,7 +37,7 @@ class ResearchTransformer extends TransformerAbstract
                     'title' => $document->documentTitle,
                     'url' => $asset->url,
                     'filetype' => $asset->kind,
-                    'filesize' => StringHelpers::formatBytes($asset->size),
+                    'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0),
                     'contents' => $document->documentContents ? explode("\n", $document->documentContents) : [],
                 ];
             }, $entry->researchDocuments->all() ?? []),

--- a/tests/StringHelpersTest.php
+++ b/tests/StringHelpersTest.php
@@ -14,4 +14,16 @@ final class StringHelpersTest extends TestCase
         $this->assertEquals('3.6 MB', StringHelpers::formatBytes(3774873.6));
         $this->assertEquals('1 GB', StringHelpers::formatBytes(1073741824));
     }
+
+    public function testFormatBytesWithPrecision(): void
+    {
+        $this->assertEquals('856.43 KB', StringHelpers::formatBytes(876986));
+        $this->assertEquals('856 KB', StringHelpers::formatBytes(876986, 0));
+
+        $this->assertEquals('100 B', StringHelpers::formatBytes(100, 0));
+        $this->assertEquals('1 KB', StringHelpers::formatBytes(1024, 0));
+        $this->assertEquals('1 MB', StringHelpers::formatBytes(1048576, 0));
+        $this->assertEquals('4 MB', StringHelpers::formatBytes(3774873.6, 0));
+        $this->assertEquals('1 GB', StringHelpers::formatBytes(1073741824, 0));
+    }
 }


### PR DESCRIPTION
Default precision of 2dp is more than we need on the front-end so updating out use to round the value:

![image](https://user-images.githubusercontent.com/123386/44455036-f7a21d00-a5f4-11e8-9d82-5d6314b7f7dd.png)

will now appear as 824 KB