### PR TITLE
Add an endpoint for a single Data page

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -841,16 +841,27 @@ function getDataPage($locale)
 {
     normaliseCacheHeaders();
 
+    $statuses = ['live', 'expired'];
+
+    /**
+     * Allow disabled versions when requesting drafts
+     * to support previews of brand new or disabled pages.
+     */
+    if (EntryHelpers::isDraftOrVersion()) {
+        $statuses[] = 'disabled';
+    }
+
     return [
         'serializer' => 'jsonApi',
         'elementType' => Entry::class,
         'criteria' => [
             'site' => $locale,
             'section' => 'data',
+            'status' => $statuses
         ],
         'one' => true,
         'transformer' => function (Entry $entry) use ($locale) {
-
+            list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
             $stats = [];
             foreach ($entry->stats as $s) {
                 $statData = [

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -834,6 +834,50 @@ function getStatRegions($locale)
     ];
 }
 
+/**
+ * API Endpoint: Data single
+ */
+function getDataPage($locale)
+{
+    normaliseCacheHeaders();
+
+    return [
+        'serializer' => 'jsonApi',
+        'elementType' => Entry::class,
+        'criteria' => [
+            'section' => 'data',
+        ],
+        'one' => true,
+        'transformer' => function (Entry $entry) use ($locale) {
+
+            $stats = [];
+            foreach ($entry->stats as $s) {
+                $statData = [
+                    'title' => $s->statTitle,
+                    'value' => $s->statValue,
+                    'showNumberBeforeTitle' => $s->showNumberBeforeTitle
+                ];
+                if ($s->suffix) {
+                    $statData['suffix'] = $s->suffix;
+                }
+                if ($s->prefix) {
+                    $statData['prefix'] = $s->prefix;
+                }
+                $stats[] = $statData;
+            }
+
+            $data['stats'] = $stats;
+
+            return [
+                'id' => $entry->id,
+                'title' => $entry->title,
+                'url' => $entry->url,
+                'stats' => $stats
+            ];
+        },
+    ];
+}
+
 function getMerchandise($locale)
 {
     normaliseCacheHeaders();
@@ -917,8 +961,9 @@ return [
         'api/v1/<locale:en|cy>/blog/tags/<tag:{slug}>' => getBlogpostsByTag,
         'api/v1/<locale:en|cy>/blog/<categorySlug:{slug}>' => getBlogpostsByCategory,
         'api/v1/<locale:en|cy>/blog/<categorySlug:{slug}>/<subCategorySlug:{slug}>' => getBlogpostsByCategory,
-        'api/v1/<locale:en|cy>/stat-blocks/' => getStatBlocks,
-        'api/v1/<locale:en|cy>/stat-regions/' => getStatRegions,
+        'api/v1/<locale:en|cy>/stat-blocks' => getStatBlocks,
+        'api/v1/<locale:en|cy>/stat-regions' => getStatRegions,
+        'api/v1/<locale:en|cy>/data' => getDataPage,
         'api/v1/<locale:en|cy>/aliases' => getAliases,
         'api/v1/<locale:en|cy>/merchandise' => getMerchandise,
         'api/v1/list-routes' => getRoutes,

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -841,23 +841,13 @@ function getDataPage($locale)
 {
     normaliseCacheHeaders();
 
-    $statuses = ['live', 'expired'];
-
-    /**
-     * Allow disabled versions when requesting drafts
-     * to support previews of brand new or disabled pages.
-     */
-    if (EntryHelpers::isDraftOrVersion()) {
-        $statuses[] = 'disabled';
-    }
-
     return [
         'serializer' => 'jsonApi',
         'elementType' => Entry::class,
         'criteria' => [
             'site' => $locale,
             'section' => 'data',
-            'status' => $statuses
+            'status' => EntryHelpers::getVersionStatuses()
         ],
         'one' => true,
         'transformer' => function (Entry $entry) use ($locale) {

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -864,18 +864,13 @@ function getDataPage($locale)
             list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
             $stats = [];
             foreach ($entry->stats as $s) {
-                $statData = [
+                $stats[] = [
                     'title' => $s->statTitle,
                     'value' => $s->statValue,
-                    'showNumberBeforeTitle' => $s->showNumberBeforeTitle
+                    'showNumberBeforeTitle' => $s->showNumberBeforeTitle,
+                    'suffix' => $s->suffix ?? null,
+                    'prefix' => $s->prefix ?? null
                 ];
-                if ($s->suffix) {
-                    $statData['suffix'] = $s->suffix;
-                }
-                if ($s->prefix) {
-                    $statData['prefix'] = $s->prefix;
-                }
-                $stats[] = $statData;
             }
 
             $data['stats'] = $stats;

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -845,6 +845,7 @@ function getDataPage($locale)
         'serializer' => 'jsonApi',
         'elementType' => Entry::class,
         'criteria' => [
+            'site' => $locale,
             'section' => 'data',
         ],
         'one' => true,


### PR DESCRIPTION
As per @davidrapson's suggestion, this reworks the Data page stats so they're embedded in a Matrix field on a single page, eg:

![image](https://user-images.githubusercontent.com/394376/45295009-29701a80-b4f5-11e8-98ca-c17b07abdd08.png)

The [corresponding PR](https://github.com/biglotteryfund/blf-alpha/pull/1270) for the website uses this new endpoint to power the Data page.