### PR TITLE
Add a basic grant ID field for heroes and case studies

### DIFF
--- a/lib/EntryHelpers.php
+++ b/lib/EntryHelpers.php
@@ -240,6 +240,7 @@ class EntryHelpers
             'trailText' => $entry->caseStudyTrailText,
             'trailTextMore' => $entry->caseStudyTrailTextMore,
             'grantAmount' => $entry->caseStudyGrantAmount,
+            'grantId' => $entry->caseStudyGrantId ? $entry->caseStudyGrantId : null,
             'thumbnailUrl' => Images::imgixUrl($entry->caseStudyThumbnailImage->one()->url, [
                 'w' => 600,
                 'h' => 400,

--- a/lib/Images.php
+++ b/lib/Images.php
@@ -76,7 +76,8 @@ class Images
             'default' => $imageMedium,
             'small' => $imageSmall,
             'medium' => $imageMedium,
-            'large' => $imageLarge
+            'large' => $imageLarge,
+            'grantId' => $heroEntry->heroGrantId ? $heroEntry->heroGrantId : null,
         ];
     }
 


### PR DESCRIPTION
Allows us to link a grant to a hero image or case study.

Down the line this could be a plugin which allows a lookup/search for the ID, but MVP and all that. 

![image](https://user-images.githubusercontent.com/394376/47222567-0156bf80-d3af-11e8-96e1-76ad5b31067f.png)
