### PR TITLE
Redactor tweak

### DIFF
--- a/config/cp-css.php
+++ b/config/cp-css.php
@@ -1,7 +1,0 @@
-<?php
-// https://github.com/doublesecretagency/craft-cpcss
-return [
-    '*' => [
-        'cssFile' => '/custom/admin.css'
-    ]
-];

--- a/config/redactor/Basics.json
+++ b/config/redactor/Basics.json
@@ -1,5 +1,6 @@
 {
     "buttons": ["formatting", "bold", "italic", "unorderedlist", "orderedlist", "link"],
     "formatting": ["p", "h2", "h3", "h4", "h5"],
-    "plugins": ["fullscreen"]
+    "plugins": ["fullscreen"],
+    "spellcheck": false
 }

--- a/config/redactor/Full.json
+++ b/config/redactor/Full.json
@@ -1,5 +1,6 @@
 {
     "buttons": ["html", "formatting", "bold", "italic", "unorderedlist", "orderedlist", "link", "image", "video", "file"],
     "formatting": ["p", "blockquote", "h2", "h3", "h4", "h5"],
-    "plugins": ["fullscreen", "video", "table", "linkButton"]
+    "plugins": ["fullscreen", "video", "table", "linkButton"],
+    "spellcheck": false
 }

--- a/config/redactor/Minimal.json
+++ b/config/redactor/Minimal.json
@@ -1,3 +1,4 @@
 {
-	"buttons": ["bold", "italic"]
+	"buttons": ["bold", "italic"],
+	"spellcheck": false
 }


### PR DESCRIPTION
Noticed something today whilst publishing a welsh language popup. Reactor (or the browser) seemed to get confused about the language and show spelling warnings everywhere. Once the spellchecking kicked in the editor was a bit sluggish. Trying disabling as a first pass but I don't know if there's some thing off which what language Redactor thinks it's in.