### PR TITLE
Remove unused cpcss file

### DIFF
--- a/config/cp-css.php
+++ b/config/cp-css.php
@@ -1,7 +1,0 @@
-<?php
-// https://github.com/doublesecretagency/craft-cpcss
-return [
-    '*' => [
-        'cssFile' => '/custom/admin.css'
-    ]
-];


### PR DESCRIPTION
Supersedes https://github.com/biglotteryfund/craft-dev/pull/97

Removes a file we don't need anymore from an old plugin.