### PR TITLE
Rework our people endpoint

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -312,7 +312,7 @@ function getFundingProgramme($locale, $slug)
 /**
  * API Endpoint: Get our people
  */
-function getOurPeople($locale, $slug = null)
+function getOurPeople($locale)
 {
     normaliseCacheHeaders();
 
@@ -321,7 +321,6 @@ function getOurPeople($locale, $slug = null)
         'elementType' => Entry::class,
         'criteria' => [
             'site' => $locale,
-            'slug' => $slug,
             'section' => 'people',
             'status' => EntryHelpers::getVersionStatuses(),
         ],

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -7,14 +7,12 @@ use craft\elements\Entry;
 
 class ContentHelpers
 {
-    public static function getCommonDetailFields(Entry $entry, $locale)
+    public static function getCommonDetailFields(Entry $entry, $status, $locale)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-
         return [
             'id' => $entry->id,
-            'status' => $status,
             'slug' => $entry->slug,
+            'status' => $status,
             'postDate' => $entry->postDate,
             'dateCreated' => $entry->dateCreated,
             'dateUpdated' => $entry->dateUpdated,

--- a/lib/People.php
+++ b/lib/People.php
@@ -16,7 +16,7 @@ class PeopleTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $common = ContentHelpers::getCommonDetailFields($entry, $this->locale);
+        $common = ContentHelpers::getCommonDetailFields($entry, $status, $this->locale);
 
         return array_merge($common, [
             'people' => array_map(function ($person) {

--- a/lib/People.php
+++ b/lib/People.php
@@ -18,30 +18,38 @@ class PeopleTransformer extends TransformerAbstract
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
         $common = ContentHelpers::getCommonDetailFields($entry, $this->locale);
 
-        $documents = $entry->documents->one();
-
         return array_merge($common, [
             'people' => array_map(function ($person) {
+                $image = $person->personPhoto->one() ?? null;
                 return [
                     'name' => $person->personName,
                     'role' => $person->personRole ?? null,
-                    'image' => Images::extractImageUrl($person->personPhoto),
-                    'bio' => $person->personBio
+                    'image' => $image ? [
+                        // Is the source image large or small?
+                        // Used to determine what layout to use
+                        'type' => $image->width > 500 ? 'large' : 'small',
+                        'url' => Images::imgixUrl(
+                            $image->url,
+                            ['fit' => 'crop', 'crop' => 'entropy', 'max-w' => 1200]
+                        ),
+                    ] : null,
+                    'bio' => $person->personBio,
                 ];
             }, $entry->people->all() ?? []),
-            'documents' => $documents ? [
-                'title' => $documents->documentsTitle,
-                'files' => array_map(function ($document) {
-                    $file = $document->documentFile->one();
-                    return [
-                        'label' => $document->documentTitle,
-                        'caption' => $document->documentDescription ?? null,
-                        'href' => $file->url,
-                        'filetype' => $file->kind,
-                        'filesize' => StringHelpers::formatBytes($file->size, $precision = 0),
-                    ];
-                }, $documents->documents->all() ?? []),
-            ] : null
+            'documentGroups' => array_map(function ($group) {
+                return [
+                    'title' => $group->documentsTitle,
+                    'files' => array_map(function ($file) {
+                        return [
+                            'label' => $file->title,
+                            'href' => $file->url,
+                            'filetype' => $file->extension,
+                            'filesize' => StringHelpers::formatBytes($file->size, $precision = 0),
+                        ];
+                    }, $group->documentsFiles->all() ?? []),
+                    'extraContent' => $group->documentsExtra ?? null,
+                ];
+            }, $entry->documentGroups->all() ?? []),
         ]);
     }
 }

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -16,7 +16,8 @@ class ResearchTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $common = ContentHelpers::getCommonDetailFields($entry, $this->locale);
+        $common = ContentHelpers::getCommonDetailFields($entry, $status, $this->locale);
+
         $researchMeta = $entry->researchMeta->one();
 
         $heroImageField = Images::extractImage($entry->heroImage);


### PR DESCRIPTION
Reworks the our people endpoint to:

- Provide more fields for the image to help us differentiate between large images and legacy thumbnail images
- Allow multiple groups of documents (e.g. to separate minutes and expenses) rather than a single group