### PR TITLE
Add tag authors tool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "biglotteryfund/preview-button": "^1.0",
     "league/uri": "^5.2",
     "imgix/imgix-php": "^2.1",
-    "verbb/super-table": "^2.0"
+    "verbb/super-table": "^2.0",
+    "ether/tags": "^1.0"
   },
   "autoload" : {
     "psr-4" : {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "37a1fb3db0861760a255800f49b1ad09",
+    "content-hash": "8c83637c5df68a19e3292d210a2c0c82",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1193,6 +1193,55 @@
             ],
             "description": "An SVG sanitizer for PHP",
             "time": "2018-07-19T17:21:27+00:00"
+        },
+        {
+            "name": "ether/tags",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ethercreative/tags.git",
+                "reference": "9880668b21710c1986883f547462f83a1d5fcb07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ethercreative/tags/zipball/9880668b21710c1986883f547462f83a1d5fcb07",
+                "reference": "9880668b21710c1986883f547462f83a1d5fcb07",
+                "shasum": ""
+            },
+            "require": {
+                "craftcms/cms": "^3.0.0-RC17"
+            },
+            "type": "craft-plugin",
+            "extra": {
+                "name": "Tags",
+                "handle": "tag-manager",
+                "changelogUrl": "https://raw.githubusercontent.com/ethercreative/tags/master/CHANGELOG.md",
+                "class": "ether\\tagManager\\TagManager"
+            },
+            "autoload": {
+                "psr-4": {
+                    "ether\\tagManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "authors": [
+                {
+                    "name": "Ether Creative",
+                    "homepage": "https://ethercreative.co.uk"
+                }
+            ],
+            "description": "A tag manager for Craft 3",
+            "keywords": [
+                "Craft",
+                "cms",
+                "craft-plugin",
+                "craftcms",
+                "tags"
+            ],
+            "time": "2018-09-27T20:14:27+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -38,7 +38,7 @@ class ContentHelpers
     public static function tagSummary($tag, $locale)
     {
         $tagGroup = $tag->getGroup();
-        return [
+        $basicFields = [
             'id' => (int) $tag->id,
             'title' => $tag->title,
             'slug' => $tag->slug,
@@ -46,6 +46,25 @@ class ContentHelpers
             'groupTitle' => $tagGroup->name,
             'link' => EntryHelpers::uriForLocale("blog/{$tagGroup->handle}/{$tag->slug}", $locale),
         ];
+
+        if ($tagGroup->handle === 'authors') {
+            $basicFields['authorTitle'] = $tag->authorTitle ?? null;
+            $basicFields['shortBiography'] = $tag->shortBiography ?? null;
+            $basicFields['fullBiography'] = $tag->fullBiography ?? null;
+            $photoUrl = Images::extractImageUrl($tag->photo);
+            if ($photoUrl) {
+                $basicFields['photo'] = Images::imgixUrl(
+                    $photoUrl,
+                    [
+                        'w' => 200,
+                        'h' => 200,
+                        'crop' => 'faces',
+                    ]
+                );
+            }
+        }
+
+        return $basicFields;
     }
 
     public static function getTags($tagField, $locale)


### PR DESCRIPTION
This adds a tag plugin which allows editing(!) of tags and their related fields:

![image](https://user-images.githubusercontent.com/394376/48768779-f1821200-ecb1-11e8-9bc6-e29e13b286da.png)

We can then output those fields for (existing) blogs and new "updates":

![image](https://user-images.githubusercontent.com/394376/48768805-0363b500-ecb2-11e8-9b20-8ed93071ff89.png)

Possibly Craft will add a core feature for tag editing, but until they do, this looks good to me.