### PR TITLE
Show all programmes

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -262,6 +262,7 @@ function getFundingProgrammes($locale)
 
     $showAll = \Craft::$app->request->getParam('all');
     $status = $showAll ? ['live', 'expired'] : ['live'];
+    $orderBy = $showAll ? 'title asc' : 'lft'; // `lft` is the structure order
 
     return [
         'serializer' => 'jsonApi',
@@ -270,7 +271,8 @@ function getFundingProgrammes($locale)
             'section' => 'fundingProgrammes',
             'site' => $locale,
             'status' => $status,
-            'programmeStatus' => 'open'
+            'programmeStatus' => 'open',
+            'orderBy' => $orderBy
         ],
         'elementsPerPage' => \Craft::$app->request->getParam('page-limit') ?: 10,
         'transformer' => function (Entry $entry) use ($locale) {

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -256,14 +256,19 @@ function getFundingProgrammes($locale)
 {
     normaliseCacheHeaders();
 
+    $showAll = \Craft::$app->request->getParam('all');
+    $status = $showAll ? ['live', 'expired'] : ['live'];
+
     return [
         'serializer' => 'jsonApi',
         'elementType' => Entry::class,
         'criteria' => [
             'section' => 'fundingProgrammes',
             'site' => $locale,
-            'status' => 'live',
+            'status' => $status,
+            'programmeStatus' => 'open'
         ],
+        'elementsPerPage' => \Craft::$app->request->getParam('page-limit') ?: 10,
         'transformer' => function (Entry $entry) use ($locale) {
             return [
                 'id' => $entry->id,

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -38,13 +38,17 @@ function getFundingProgramMatrix($entry, $locale)
 
                     // Use custom thumbnail if one is set, otherwise default to hero image.
                     $heroImage = Images::extractImage($entry->heroImage);
-                    $thumbnailSrc = Images::extractImage($block->photo) ?? $heroImage->imageMedium->one();
+                    $thumbnailSrc = Images::extractImage($block->photo) ?? ($heroImage ? $heroImage->imageMedium->one() : null);
 
-                    $fundingData['photo'] = Images::imgixUrl($thumbnailSrc->url, [
-                        'w' => 100,
-                        'h' => 100,
-                        'crop' => 'faces',
-                    ]);
+                    if ($thumbnailSrc) {
+                        $fundingData['photo'] = Images::imgixUrl($thumbnailSrc->url, [
+                            'w' => 100,
+                            'h' => 100,
+                            'crop' => 'faces',
+                        ]);
+                    } else {
+                        $fundingData['photo'] = null;
+                    }
 
                     $image = $heroImage ? $heroImage->imageMedium->one() : null;
                     $fundingData['image'] = $image ? Images::imgixUrl($image->url, [

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -311,6 +311,38 @@ function getFundingProgramme($locale, $slug)
 }
 
 /**
+ * API Endpoint: Get Funding Programmes
+ * Get full details of a single funding programme
+ */
+function getFundingProgrammesNext($locale, $slug = null)
+{
+    normaliseCacheHeaders();
+
+    $showAll = \Craft::$app->request->getParam('all');
+
+    $criteria = [
+        'section' => 'fundingProgrammes',
+        'site' => $locale,
+        'status' => $showAll ? ['live', 'expired'] : EntryHelpers::getVersionStatuses(),
+        'programmeStatus' => 'open'
+    ];
+
+    if ($slug) {
+        $criteria['slug'] = $slug;
+    } else if ($showAll) {
+        $criteria['orderBy'] = 'title asc';
+    }
+
+    return [
+        'serializer' => 'jsonApi',
+        'elementType' => Entry::class,
+        'criteria' => $criteria,
+        'one' => $slug ? true : false,
+        'transformer' => new FundingProgrammeTransformer($locale, 2),
+    ];
+}
+
+/**
  * API Endpoint: Get our people
  */
 function getOurPeople($locale)
@@ -910,6 +942,8 @@ return [
         'api/v1/<locale:en|cy>/case-studies' => getCaseStudies,
         'api/v1/<locale:en|cy>/funding-programme/<slug>' => getFundingProgramme,
         'api/v1/<locale:en|cy>/funding-programmes' => getFundingProgrammes,
+        'api/v2/<locale:en|cy>/funding-programmes/<slug>' => getFundingProgrammesNext,
+        'api/v2/<locale:en|cy>/funding-programmes' => getFundingProgrammesNext,
         'api/v1/<locale:en|cy>/research' => getResearch,
         'api/v1/<locale:en|cy>/research/<slug>' => getResearchDetail,
         'api/v1/<locale:en|cy>/strategic-programmes' => getStrategicProgrammes,


### PR DESCRIPTION
This adds a field to the CMS called "programme status":

![image](https://user-images.githubusercontent.com/394376/48771342-12019a80-ecb9-11e8-8180-f0aea1154f10.png)

This allows us to distinguish between things that could be applied for directly (eg. now or in the past), and things that can't (eg. BBO). 

This then means we can pass `?all=true` to the programmes endpoint to get a list of expired programmes – eg. legacy programmes that aren't open to applicants anymore, but once were. This still excludes the strategic ones like BBO.

This still needs a bit of finessing on the other end (eg. how do we display these expired programmes?) but gives us the capability to launch them.

Nothing changes when we merge this, but we'd eventually want to stop using the "expired programme hack" we're currently using to hide BBO from the list in favour of using this.