### PR TITLE
Add regions to updates endpoint

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -751,6 +751,7 @@ function getUpdates($locale, $type = null, $date = null, $slug = null)
         'activeAuthor' => null,
         'activeTag' => null,
         'activeCategory' => null,
+        'activeRegion' => null,
         'pageType' => 'single',
         'regions' => ContentHelpers::nestedCategorySummary(Category::find()->group('region')->all(), $locale)
     ];
@@ -793,7 +794,7 @@ function getUpdates($locale, $type = null, $date = null, $slug = null)
     } else if ($regionQuery) {
         $activeRegion = Category::find()->group('region')->slug($regionQuery)->one();
         if ($activeRegion) {
-            $meta['pageType'] = 'category';
+            $meta['pageType'] = 'region';
             $meta['activeRegion'] = ContentHelpers::categorySummary($activeRegion, $locale);
             $criteria['relatedTo'] = [
                 'targetElement' => $activeRegion,

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -266,7 +266,7 @@ function getFundingProgrammes($locale)
         'criteria' => [
             'section' => 'fundingProgrammes',
             'site' => $locale,
-            'status' => 'live'
+            'status' => 'live',
         ],
         'transformer' => function (Entry $entry) use ($locale) {
             return [
@@ -317,7 +317,7 @@ function getFundingProgrammesNext($locale, $slug = null)
         'section' => 'fundingProgrammes',
         'site' => $locale,
         'status' => $showAll ? ['live', 'expired'] : EntryHelpers::getVersionStatuses(),
-        'programmeStatus' => 'open'
+        'programmeStatus' => 'open',
     ];
 
     if ($slug) {
@@ -753,7 +753,7 @@ function getUpdates($locale, $type = null, $date = null, $slug = null)
         'activeCategory' => null,
         'activeRegion' => null,
         'pageType' => 'single',
-        'regions' => ContentHelpers::nestedCategorySummary(Category::find()->group('region')->all(), $locale)
+        'regions' => ContentHelpers::nestedCategorySummary(Category::find()->group('region')->all(), $locale),
     ];
 
     if ($isSinglePost) {
@@ -816,6 +816,7 @@ function getUpdates($locale, $type = null, $date = null, $slug = null)
     ];
 }
 
+// @TODO: Remove me once launching updates to data page
 function getStatRegions($locale)
 {
     normaliseCacheHeaders();
@@ -865,10 +866,25 @@ function getDataPage($locale)
                 'status' => $status
             ) = EntryHelpers::getDraftOrVersionOfEntry($entry);
 
+            $regionStats = $entry->regionStats->one();
             return [
                 'id' => $entry->id,
                 'title' => $entry->title,
                 'url' => $entry->url,
+                'regions' => [
+                    'england' => array_map(function ($row) {
+                        return ['label' => $row['label'], 'value' => $row['value']];
+                    }, $regionStats->england),
+                    'northernIreland' => array_map(function ($row) {
+                        return ['label' => $row['label'], 'value' => $row['value']];
+                    }, $regionStats->northernIreland),
+                    'scotland' => array_map(function ($row) {
+                        return ['label' => $row['label'], 'value' => $row['value']];
+                    }, $regionStats->scotland),
+                    'wales' => array_map(function ($row) {
+                        return ['label' => $row['label'], 'value' => $row['value']];
+                    }, $regionStats->wales),
+                ],
                 'stats' => array_map(function ($stat) {
                     return [
                         'title' => $stat->statTitle,
@@ -877,7 +893,7 @@ function getDataPage($locale)
                         'suffix' => $stat->suffix ?? null,
                         'prefix' => $stat->prefix ?? null,
                     ];
-                }, $entry->stats->all() ?? []),
+                }, $entry->stats->all() ?? [])
             ];
         },
     ];

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -26,12 +26,34 @@ class ContentHelpers
         ];
     }
 
+    public static function nestedCategorySummary($categories, $locale)
+    {
+        $data = [];
+        foreach ($categories as $category) {
+            if ($category->level == 1) {
+                $summary = self::categorySummary($category, $locale);
+                
+                $children = [];
+                foreach ($categories as $childCategory) {
+                    if ($category->isAncestorOf($childCategory)) {
+                        $children[] = self::categorySummary($childCategory, $locale);
+                    }
+                }
+                    
+                $summary['children'] = $children;
+                $data[] = $summary;
+            }
+        }
+
+        return $data;
+    }
+
     public static function categorySummary($category, $locale)
     {
         return [
             'title' => $category->title,
             'link' => EntryHelpers::uriForLocale($category->uri, $locale),
-            'slug' => $category->slug,
+            'slug' => $category->slug
         ];
     }
 

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -27,6 +27,7 @@ class UpdatesTransformer extends TransformerAbstract
             'thumbnail' =>  $trailPhotoUrl ? Images::getStandardCrops($trailPhotoUrl) : null,
             'category' => $primaryCategory ? ContentHelpers::categorySummary($primaryCategory, $this->locale) : null,
             'authors' => ContentHelpers::getTags($entry->authors->all(), $this->locale),
+            'regions' => $entry->regions ? ContentHelpers::nestedCategorySummary($entry->regions->all(), $this->locale) : [],
             'tags' => ContentHelpers::getTags($entry->tags->all(), $this->locale),
             'summary' => $entry->articleSummary,
             'content' => ContentHelpers::extractFlexibleContent($entry),


### PR DESCRIPTION
A little work in progress. Returns the full list of regions in `meta` as well as the associated regions 

Does a little juggling to get the categories in a nested structure as although the CMS handles nested behaviour nicely the element query returns a flat list so we need to re-construct the nesting.

![image](https://user-images.githubusercontent.com/123386/49151936-3688f280-f309-11e8-84c4-65ecdbce315a.png)
