### PR TITLE
Add common image sizes to blog trail thumbnail

### DIFF
--- a/lib/Images.php
+++ b/lib/Images.php
@@ -68,7 +68,7 @@ class Images
         return $image ? $image->url : null;
     }
 
-    public static function getHeroImageCrops($imageUrl)
+    public static function getStandardCrops($imageUrl)
     {
         return [
             'small' => self::imgixUrl(

--- a/lib/Images.php
+++ b/lib/Images.php
@@ -5,6 +5,21 @@ namespace biglotteryfund\utils;
 use Imgix\UrlBuilder;
 use League\Uri\Parser;
 
+const IMAGE_SIZES = [
+    'small' => [
+        'w' => '644',
+        'h' => '425'
+    ],
+    'medium' => [
+        'w' => '1280',
+        'h' => '720'
+    ],
+    'large' => [
+        'w' => '1373',
+        'h' => '405'
+    ]
+];
+
 class Images
 {
     private static function _getImgixConfig()
@@ -53,21 +68,39 @@ class Images
         return $image ? $image->url : null;
     }
 
+    public static function getHeroImageCrops($imageUrl)
+    {
+        return [
+            'small' => self::imgixUrl(
+                $imageUrl,
+                IMAGE_SIZES['small']
+            ),
+            'medium' => self::imgixUrl(
+                $imageUrl,
+                IMAGE_SIZES['medium']
+            ),
+            'large' => self::imgixUrl(
+                $imageUrl,
+                IMAGE_SIZES['large']
+            ),
+        ];
+    }
+
     public static function buildHeroImage($heroEntry)
     {
         $imageSmall = self::imgixUrl(
             $heroEntry->imageSmall->one()->url,
-            ['w' => '644 ', 'h' => '425']
+            IMAGE_SIZES['small']
         );
 
         $imageMedium = self::imgixUrl(
             $heroEntry->imageMedium->one()->url,
-            ['w' => '1280', 'h' => '720']
+            IMAGE_SIZES['medium']
         );
 
         $imageLarge = self::imgixUrl(
             $heroEntry->imageLarge->one()->url,
-            ['w' => '1373 ', 'h' => '405']
+            IMAGE_SIZES['large']
         );
 
         return [

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -19,9 +19,12 @@ class UpdatesTransformer extends TransformerAbstract
         $commonFields = ContentHelpers::getCommonDetailFields($entry, $status, $this->locale);
         $primaryCategory = $entry->category ? $entry->category->inReverse()->one() : null;
 
+        $trailPhotoUrl = $entry->trailPhoto->one() ? $entry->trailPhoto->one()->url : null;
+
         $extraFields = [
             'promoted' => $entry->articlePromoted,
             'trailPhoto' => Images::extractImageUrl($entry->trailPhoto), // @TODO Raw image. What size(s) should we crop this to?
+            'thumbnail' =>  $trailPhotoUrl ? Images::getHeroImageCrops($trailPhotoUrl) : null,
             'category' => $primaryCategory ? ContentHelpers::categorySummary($primaryCategory, $this->locale) : null,
             'authors' => ContentHelpers::getTags($entry->authors->all(), $this->locale),
             'tags' => ContentHelpers::getTags($entry->tags->all(), $this->locale),

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -24,7 +24,7 @@ class UpdatesTransformer extends TransformerAbstract
         $extraFields = [
             'promoted' => $entry->articlePromoted,
             'trailPhoto' => Images::extractImageUrl($entry->trailPhoto), // @TODO Raw image. What size(s) should we crop this to?
-            'thumbnail' =>  $trailPhotoUrl ? Images::getHeroImageCrops($trailPhotoUrl) : null,
+            'thumbnail' =>  $trailPhotoUrl ? Images::getStandardCrops($trailPhotoUrl) : null,
             'category' => $primaryCategory ? ContentHelpers::categorySummary($primaryCategory, $this->locale) : null,
             'authors' => ContentHelpers::getTags($entry->authors->all(), $this->locale),
             'tags' => ContentHelpers::getTags($entry->tags->all(), $this->locale),


### PR DESCRIPTION
This shares the hero image dimensions with the blog trail image, so we can use different crops as necessary (potentially using them like hero images if we want to, although it makes the crops from the same single image rather than three of them).