### PR TITLE
Enhance update listings

### DIFF
--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -51,7 +51,7 @@ class ContentHelpers
             $basicFields['authorTitle'] = $tag->authorTitle ?? null;
             $basicFields['shortBiography'] = $tag->shortBiography ?? null;
             $basicFields['fullBiography'] = $tag->fullBiography ?? null;
-            $photoUrl = Images::extractImageUrl($tag->photo);
+            $photoUrl = $tag->photo ? Images::extractImageUrl($tag->photo) : null;
             if ($photoUrl) {
                 $basicFields['photo'] = Images::imgixUrl(
                     $photoUrl,

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -44,6 +44,25 @@ class UpdatesTransformer extends TransformerAbstract
             ],
         ];
 
+        $siblingCriteria = [
+            'section' => 'updates',
+            'type' => $entry->type->handle,
+        ];
+
+        $nextPost = $entry->getNext($siblingCriteria);
+        $prevPost = $entry->getPrev($siblingCriteria);
+
+        $extraFields['siblings'] = [
+            'next' => $nextPost ? [
+                'title' => $nextPost->title,
+                'linkUrl' => $nextPost->url,
+            ] : null,
+            'prev' => $prevPost ? [
+                'title' => $prevPost->title,
+                'linkUrl' => $prevPost->url,
+            ] : null,
+        ];
+
         if ($entry->type->handle === 'press_releases') {
             $extraFields['contacts'] = $entry->pressReleaseContacts ?? null;
             $extraFields['notesToEditors'] = $entry->pressReleaseNotesToEditors ?? null;

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -23,7 +23,7 @@ class UpdatesTransformer extends TransformerAbstract
 
         $extraFields = [
             'promoted' => $entry->articlePromoted,
-            'trailPhoto' => Images::extractImageUrl($entry->trailPhoto), // @TODO Raw image. What size(s) should we crop this to?
+            'trailPhoto' => Images::extractImageUrl($entry->trailPhoto),
             'thumbnail' =>  $trailPhotoUrl ? Images::getStandardCrops($trailPhotoUrl) : null,
             'category' => $primaryCategory ? ContentHelpers::categorySummary($primaryCategory, $this->locale) : null,
             'authors' => ContentHelpers::getTags($entry->authors->all(), $this->locale),

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -30,6 +30,14 @@ class UpdatesTransformer extends TransformerAbstract
             'tags' => ContentHelpers::getTags($entry->tags->all(), $this->locale),
             'summary' => $entry->articleSummary,
             'content' => ContentHelpers::extractFlexibleContent($entry),
+            'relatedFundingProgrammes' => array_map(function ($programme) {
+                return [
+                    'title' => $programme->title,
+                    'linkUrl' => $programme->externalUrl ? $programme->externalUrl : EntryHelpers::uriForLocale($programme->uri, $this->locale),
+                    'photo' => Images::extractHeroImage($programme->heroImage),
+                    'intro' => $programme->programmeIntro,
+                ];
+            }, $entry->relatedFundingProgrammes->all() ?? []),
             'updateType' => [
                 'name' => $entry->type->name,
                 'slug' => str_replace('_', '-', $entry->type->handle),


### PR DESCRIPTION
This adds sibling entries (eg. prev/next) and related funding programmes to the API for Updates.

![image](https://user-images.githubusercontent.com/394376/49167277-f89dc580-f32c-11e8-9507-a4a5c88449e8.png)
