### PR TITLE
Support new hero image fields

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -117,13 +117,31 @@ function getRoutes()
 {
     normaliseCacheHeaders();
 
+    $allSectionHandles = array_map(function ($section) {
+        return $section->handle;
+    }, \Craft::$app->sections->allSections);
+
+    $excludeList = [
+        'aliases',
+        'caseStudies',
+        'documents',
+        'heroImage',
+        'homepage',
+        'merchandise',
+        'news',
+        // @TODO: Remove when launching this section
+        'updates'
+    ];
+
+    $allowedSectionHandles = array_diff($allSectionHandles, $excludeList);
+
     return [
         'serializer' => 'jsonApi',
         'elementType' => Entry::class,
         'elementsPerPage' => 1000,
         'criteria' => [
-            'section' => ['about', 'fundingProgrammes', 'fundingGuidance', 'buildingBetterOpportunities'],
-            'status' => ['live', 'pending', 'expired'],
+            'section' => $allowedSectionHandles,
+            'status' => ['live', 'expired'],
             'orderBy' => 'uri',
         ],
         'transformer' => function (craft\elements\Entry $entry) {
@@ -132,7 +150,6 @@ function getRoutes()
                 'title' => $entry->title,
                 'path' => '/' . $entry->uri,
                 'live' => $entry->status === 'live',
-                'isFromCms' => true,
             ];
         },
     ];

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -549,15 +549,10 @@ function getFlexibleContent($locale)
         ],
         'transformer' => function (Entry $entry) use ($locale, $pagePath) {
             list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-
-            $entryData = EntryHelpers::extractBasicEntryData($entry);
-            $entryData['availableLanguages'] = EntryHelpers::getAvailableLanguages($entry->id, $locale);
-            $entryData['status'] = $status;
-            $entryData['hero'] = Images::extractHeroImage($entry->heroImage);
-
-            $entryData['flexibleContent'] = ContentHelpers::extractFlexibleContent($entry);
-
-            return $entryData;
+            $common = ContentHelpers::getCommonFields($entry, $status, $locale);
+            return array_merge($common, [
+                'flexibleContent' => ContentHelpers::extractFlexibleContent($entry)
+            ]);
         },
     ];
 }

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -547,7 +547,7 @@ function getFlexibleContent($locale)
             // Limited to certain sections using flexible content
             'section' => ['aboutLandingPage'],
         ],
-        'transformer' => function (Entry $entry) use ($locale, $pagePath) {
+        'transformer' => function (Entry $entry) use ($locale) {
             list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
             $common = ContentHelpers::getCommonFields($entry, $status, $locale);
             return array_merge($common, [

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -20,7 +20,7 @@ class ContentHelpers
         }
     }
 
-    public static function getCommonDetailFields(Entry $entry, $status, $locale)
+    public static function getCommonFields(Entry $entry, $status, $locale)
     {
         return [
             'id' => $entry->id,

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -31,6 +31,8 @@ class ContentHelpers
             'dateCreated' => $entry->dateCreated,
             'dateUpdated' => $entry->dateUpdated,
             'availableLanguages' => EntryHelpers::getAvailableLanguages($entry->id, $locale),
+            // @TODO: Is url used anywhere?
+            'url' => $entry->url,
             // @TODO: Some older pages use path instead of linkUrl in templates, update these uses and then remove this
             'path' => $entry->uri,
             'linkUrl' => $entry->externalUrl ? $entry->externalUrl : EntryHelpers::uriForLocale($entry->uri, $locale),
@@ -38,7 +40,8 @@ class ContentHelpers
             'trailText' => $entry->trailText ?? null,
             'hero' => $entry->heroImage ? Images::extractHeroImage($entry->heroImage) : null,
             'heroCredit' => $entry->heroImageCredit ?? null,
-            'heroNew' => self::extractNewHero($entry)
+            'heroNew' => self::extractNewHero($entry),
+            'themeColour' => $entry->themeColour ? $entry->themeColour->value : null
         ];
     }
 

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -31,8 +31,12 @@ class ContentHelpers
             'dateCreated' => $entry->dateCreated,
             'dateUpdated' => $entry->dateUpdated,
             'availableLanguages' => EntryHelpers::getAvailableLanguages($entry->id, $locale),
+            // @TODO: Some older pages use path instead of linkUrl in templates, update these uses and then remove this
+            'path' => $entry->uri,
             'linkUrl' => $entry->externalUrl ? $entry->externalUrl : EntryHelpers::uriForLocale($entry->uri, $locale),
             'title' => $entry->title,
+            // @TODO: Is displayTitle definitely distinct from trailText?
+            'displayTitle' => $entry->displayTitle ?? null,
             'trailText' => $entry->trailText ?? null,
             'hero' => $entry->heroImage ? Images::extractHeroImage($entry->heroImage) : null,
             'heroCredit' => $entry->heroImageCredit ?? null,

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -35,8 +35,6 @@ class ContentHelpers
             'path' => $entry->uri,
             'linkUrl' => $entry->externalUrl ? $entry->externalUrl : EntryHelpers::uriForLocale($entry->uri, $locale),
             'title' => $entry->title,
-            // @TODO: Is displayTitle definitely distinct from trailText?
-            'displayTitle' => $entry->displayTitle ?? null,
             'trailText' => $entry->trailText ?? null,
             'hero' => $entry->heroImage ? Images::extractHeroImage($entry->heroImage) : null,
             'heroCredit' => $entry->heroImageCredit ?? null,

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -7,6 +7,19 @@ use craft\elements\Entry;
 
 class ContentHelpers
 {
+    public static function extractNewHero(Entry $entry) {
+        $newHeroField = $entry->hero ? $entry->hero->one() : null;
+
+        if ($newHeroField) {
+            return [
+                'image' => $newHeroField->image ? Images::extractHeroImage($newHeroField->image) : null,
+                'credit' => $newHeroField->credit ?? null
+            ];
+        } else {
+            return null;
+        }
+    }
+
     public static function getCommonDetailFields(Entry $entry, $status, $locale)
     {
         return [
@@ -23,6 +36,7 @@ class ContentHelpers
             'trailText' => $entry->trailText ?? null,
             'hero' => $entry->heroImage ? Images::extractHeroImage($entry->heroImage) : null,
             'heroCredit' => $entry->heroImageCredit ?? null,
+            'heroNew' => self::extractNewHero($entry)
         ];
     }
 

--- a/lib/EntryHelpers.php
+++ b/lib/EntryHelpers.php
@@ -33,7 +33,6 @@ class EntryHelpers
 
     public static function uriForLocale($uri, $locale)
     {
-        // @TODO: Can craft construct this for us?
         return $locale === 'cy' ? "/welsh/$uri" : "/$uri";
     }
 
@@ -124,76 +123,8 @@ class EntryHelpers
         return $statuses;
     }
 
-    public static function getRelatedEntries($entry, $relationType, $locale)
-    {
-        $relatedEntries = [];
-        $relatedSearch = [];
 
-        if ($relationType === 'ancestors') {
-            $relatedSearch = $entry->getAncestors()->all();
-        } else if ($relationType === 'children') {
-            $relatedSearch = $entry->getChildren()->all();
-        } else if ($relationType === 'siblings') {
-            // get parent first to allow including self as a sibling
-            $parent = $entry->getParent();
-            if ($parent) {
-                $relatedSearch = $parent->getDescendants(1)->all();
-            }
-        }
-
-        foreach ($relatedSearch as $relatedItem) {
-            $relatedData = EntryHelpers::extractBasicEntryData($relatedItem);
-            $relatedData['isCurrent'] = $entry->uri == $relatedData['path'];
-            $relatedData['link'] = EntryHelpers::uriForLocale($relatedItem->uri, $locale);
-
-            $heroImage = Images::extractImage($relatedItem->heroImage);
-            $relatedData['photo'] = Images::imgixUrl($heroImage->imageSmall->one()->url, [
-                'w' => 500,
-                'h' => 333,
-                'crop' => 'faces',
-            ]);
-
-            // Some sub-pages are just links to external sites or internal files
-            // so we replace the canonical (empty) page with a link
-            $entryType = $relatedItem->type->handle;
-            if ($entryType === 'linkItem') {
-                $relatedData['entryType'] = $entryType;
-                // is this a document?
-                if ($relatedItem->documentLink && $relatedItem->documentLink->one()) {
-                    $relatedData['link'] = $relatedItem->documentLink->one()->url;
-                    // or is it an external URL?
-                } else if ($relatedItem->externalUrl) {
-                    $relatedData['link'] = $relatedItem->externalUrl;
-                }
-            }
-
-            $relatedEntries[] = $relatedData;
-        }
-
-        return $relatedEntries;
-    }
-
-    public static function extractBasicEntryData(Entry $entry)
-    {
-        $basicData = [
-            'id' => $entry->id,
-            'path' => $entry->uri,
-            'url' => $entry->url,
-            'title' => $entry->title,
-            'displayTitle' => $entry->displayTitle ?? null,
-            'dateUpdated' => $entry->dateUpdated,
-        ];
-
-        if ($entry->themeColour) {
-            $basicData['themeColour'] = $entry->themeColour->value;
-        }
-
-        if ($entry->trailText) {
-            $basicData['trailText'] = $entry->trailText;
-        }
-
-        return $basicData;
-    }
+    // @TODO: Extract all methods below here into transformers or ContentHelpers
 
     /**
      * extractNewsSummary

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -74,7 +74,7 @@ class FundingProgrammeTransformerNew extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonDetailFields($entry, $status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale);
 
         // Use custom thumbnail if one is set, otherwise default to hero image.
         $heroImage = Images::extractImage($entry->heroImage);

--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace biglotteryfund\utils;
+
+use biglotteryfund\utils\ContentHelpers;
+use craft\elements\Entry;
+use League\Fractal\TransformerAbstract;
+
+class ListingTransformer extends TransformerAbstract
+{
+    public function __construct($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    private static function extractBasicEntryData(Entry $entry)
+    {
+        $basicData = [
+            'id' => $entry->id,
+            'path' => $entry->uri,
+            'url' => $entry->url,
+            'title' => $entry->title,
+            'displayTitle' => $entry->displayTitle ?? null,
+            'dateUpdated' => $entry->dateUpdated,
+        ];
+
+        if ($entry->themeColour) {
+            $basicData['themeColour'] = $entry->themeColour->value;
+        }
+
+        if ($entry->trailText) {
+            $basicData['trailText'] = $entry->trailText;
+        }
+
+        return $basicData;
+    }
+
+    private function getRelatedEntries($entry, $relationType)
+    {
+        $relatedEntries = [];
+        $relatedSearch = [];
+
+        if ($relationType === 'ancestors') {
+            $relatedSearch = $entry->getAncestors()->all();
+        } else if ($relationType === 'children') {
+            $relatedSearch = $entry->getChildren()->all();
+        } else if ($relationType === 'siblings') {
+            // get parent first to allow including self as a sibling
+            $parent = $entry->getParent();
+            if ($parent) {
+                $relatedSearch = $parent->getDescendants(1)->all();
+            }
+        }
+
+        foreach ($relatedSearch as $relatedItem) {
+            $relatedData = self::extractBasicEntryData($relatedItem);
+            $relatedData['isCurrent'] = $entry->uri == $relatedData['path'];
+            $relatedData['link'] = EntryHelpers::uriForLocale($relatedItem->uri, $this->locale);
+
+            $heroImage = Images::extractImage($relatedItem->heroImage);
+            $relatedData['photo'] = Images::imgixUrl($heroImage->imageSmall->one()->url, [
+                'w' => 500,
+                'h' => 333,
+                'crop' => 'faces',
+            ]);
+
+            // Some sub-pages are just links to external sites or internal files
+            // so we replace the canonical (empty) page with a link
+            $entryType = $relatedItem->type->handle;
+            if ($entryType === 'linkItem') {
+                $relatedData['entryType'] = $entryType;
+                // is this a document?
+                if ($relatedItem->documentLink && $relatedItem->documentLink->one()) {
+                    $relatedData['link'] = $relatedItem->documentLink->one()->url;
+                    // or is it an external URL?
+                } else if ($relatedItem->externalUrl) {
+                    $relatedData['link'] = $relatedItem->externalUrl;
+                }
+            }
+
+            $relatedEntries[] = $relatedData;
+        }
+
+        return $relatedEntries;
+    }
+
+
+    public function transform(Entry $entry)
+    {
+        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
+        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale);
+
+        $customFields = [
+            'introduction' => $entry->introductionText ?? null,
+            'segments' => array_map(function ($block) {
+                $segmentImage = $block->segmentImage->one();
+                return [
+                    'title' => $block->segmentTitle,
+                    'content' => $block->segmentContent,
+                    'photo' => $segmentImage ? $segmentImage->url : null,
+                ];
+            }, $entry->contentSegment->all() ?? []),
+            'outro' => $entry->outroText ?? null,
+            'relatedContent' => $entry->relatedContent ?? null
+        ];
+
+        $ancestors = self::getRelatedEntries($entry, 'ancestors');
+        if (count($ancestors) > 0) {
+            $customFields['ancestors'] = $ancestors;
+        }
+
+        $children = self::getRelatedEntries($entry, 'children');
+        if (count($children) > 0) {
+            $customFields['children'] = $children;
+        }
+
+        $siblings = self::getRelatedEntries($entry, 'siblings');
+        if (count($siblings) > 0) {
+            $customFields['siblings'] = $siblings;
+        }
+
+        if ($entry->relatedCaseStudies) {
+            $customFields['caseStudies'] = EntryHelpers::extractCaseStudySummaries($entry->relatedCaseStudies->all());
+        }
+
+        return array_merge($commonFields, $customFields);
+    }
+}

--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -20,7 +20,6 @@ class ListingTransformer extends TransformerAbstract
             'path' => $entry->uri,
             'url' => $entry->url,
             'title' => $entry->title,
-            'displayTitle' => $entry->displayTitle ?? null,
             'dateUpdated' => $entry->dateUpdated,
         ];
 

--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -73,14 +73,14 @@ class ListingTransformer extends TransformerAbstract
 
         $customFields = [
             'introduction' => $entry->introductionText ?? null,
-            'segments' => array_map(function ($block) {
+            'segments' => $entry->contentSegment ? array_map(function ($block) {
                 $segmentImage = $block->segmentImage->one();
                 return [
                     'title' => $block->segmentTitle,
                     'content' => $block->segmentContent,
                     'photo' => $segmentImage ? $segmentImage->url : null,
                 ];
-            }, $entry->contentSegment->all() ?? []),
+            }, $entry->contentSegment->all() ?? []) : [],
             'outro' => $entry->outroText ?? null,
             'relatedContent' => $entry->relatedContent ?? null
         ];

--- a/lib/People.php
+++ b/lib/People.php
@@ -16,7 +16,7 @@ class PeopleTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $common = ContentHelpers::getCommonDetailFields($entry, $status, $this->locale);
+        $common = ContentHelpers::getCommonFields($entry, $status, $this->locale);
 
         return array_merge($common, [
             'people' => array_map(function ($person) {

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -16,7 +16,7 @@ class ResearchTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $common = ContentHelpers::getCommonDetailFields($entry, $status, $this->locale);
+        $common = ContentHelpers::getCommonFields($entry, $status, $this->locale);
 
         $researchMeta = $entry->researchMeta->one();
 

--- a/lib/StrategicProgrammes.php
+++ b/lib/StrategicProgrammes.php
@@ -29,24 +29,18 @@ class StrategicProgrammeTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
+        $commonFields = ContentHelpers::getCommonDetailFields($entry, $status, $this->locale);
 
         $heroImageField = Images::extractImage($entry->heroImage);
 
-        $data = [
-            'id' => $entry->id,
-            'availableLanguages' => EntryHelpers::getAvailableLanguages($entry->id, $this->locale),
-            'status' => $status,
-            'dateUpdated' => $entry->dateUpdated,
-            'title' => $entry->title,
-            'path' => $entry->externalUrl ? $entry->externalUrl : EntryHelpers::uriForLocale($entry->uri, $this->locale),
+        return array_merge($commonFields, [
+            // @TODO: Update template URLs to use linkUrl
+            'path' => $commonFields['linkUrl'],
             'sectionBreadcrumbs' => self::buildSectionBreadcrumbs($entry, $this->locale),
             'thumbnail' => $heroImageField ? Images::imgixUrl(
                 $heroImageField->imageMedium->one()->url,
                 ['w' => '640', 'h' => '360']
             ) : null,
-            'hero' => $heroImageField ? Images::buildHeroImage($heroImageField) : null,
-            'heroCredit' => $entry->heroImageCredit ?? null,
-            'trailText' => $entry->trailText,
             'intro' => $entry->programmeIntro,
             'aims' => $entry->strategicProgrammeAims,
             'impact' => array_map(function ($block) {
@@ -80,8 +74,6 @@ class StrategicProgrammeTransformer extends TransformerAbstract
                     'content' => $block->contentBody,
                 ];
             }, $entry->strategicProgrammeResources->all() ?? []),
-        ];
-
-        return $data;
+        ]);
     }
 }

--- a/lib/StrategicProgrammes.php
+++ b/lib/StrategicProgrammes.php
@@ -29,7 +29,7 @@ class StrategicProgrammeTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonDetailFields($entry, $status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale);
 
         $heroImageField = Images::extractImage($entry->heroImage);
 

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -16,7 +16,7 @@ class UpdatesTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonDetailFields($entry, $status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale);
         $primaryCategory = $entry->category ? $entry->category->inReverse()->one() : null;
 
         $trailPhotoUrl = $entry->trailPhoto->one() ? $entry->trailPhoto->one()->url : null;


### PR DESCRIPTION
Reworks our API endpoints to support both new and re-designed hero images for all content types.

Required some reworking of–mostly older–api endpoints to use the same `getCommonFields` method.