### PR TITLE
Allow up to 20MB file uploads 

### DIFF
--- a/.ebextensions/php.config
+++ b/.ebextensions/php.config
@@ -4,5 +4,5 @@ files:
     owner: root
     group: root
     content: |
-        upload_max_filesize = 10M
-        post_max_size = 10M
+        upload_max_filesize = 20M
+        post_max_size = 20M


### PR DESCRIPTION
One of the BBO Excel files is 16mb which I can't upload to Craft. This boosts it to 20mb which surely ought to be enough for anyone... right?