### PR TITLE
Don't throw an error for listing child pages without hero images

### DIFF
--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -55,11 +55,11 @@ class ListingTransformer extends TransformerAbstract
             $heroImageField = Images::extractImage($relatedEntry->heroImage);
 
             $relatedEntries[] = array_merge($commonFields, [
-                'photo' => Images::imgixUrl($heroImageField->imageSmall->one()->url, [
+                'photo' => $heroImageField ? Images::imgixUrl($heroImageField->imageSmall->one()->url, [
                     'w' => 500,
                     'h' => 333,
                     'crop' => 'faces',
-                ]),
+                ]) : null,
             ]);
         }
 


### PR DESCRIPTION
Very basic change here to prevent listing pages without heroes (eg. BBO subpages) from breaking the API.