### PR TITLE
Add project stories endpoint and transformer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "league/uri": "^5.2",
     "imgix/imgix-php": "^2.1",
     "verbb/super-table": "^2.0",
-    "ether/tags": "^1.0"
+    "ether/tags": "^1.0",
+    "doublesecretagency/craft-inventory": "^2.0"
   },
   "autoload" : {
     "psr-4" : {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c83637c5df68a19e3292d210a2c0c82",
+    "content-hash": "9d051b2b4ca50075f6b5d09d8e49e784",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1063,6 +1063,57 @@
             "time": "2014-09-09T13:34:57+00:00"
         },
         {
+            "name": "doublesecretagency/craft-inventory",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doublesecretagency/craft-inventory.git",
+                "reference": "0dd1b3a62e4bece3832fa127c1c9d178ed49d742"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doublesecretagency/craft-inventory/zipball/0dd1b3a62e4bece3832fa127c1c9d178ed49d742",
+                "reference": "0dd1b3a62e4bece3832fa127c1c9d178ed49d742",
+                "shasum": ""
+            },
+            "require": {
+                "craftcms/cms": "^3.0"
+            },
+            "type": "craft-plugin",
+            "extra": {
+                "name": "Inventory",
+                "handle": "inventory",
+                "schemaVersion": "2.0.0",
+                "changelogUrl": "https://raw.githubusercontent.com/doublesecretagency/craft-inventory/v2/CHANGELOG.md",
+                "class": "doublesecretagency\\inventory\\Inventory"
+            },
+            "autoload": {
+                "psr-4": {
+                    "doublesecretagency\\inventory\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Double Secret Agency",
+                    "homepage": "https://www.doublesecretagency.com/plugins"
+                }
+            ],
+            "description": "Take stock of your field usage.",
+            "keywords": [
+                "Craft",
+                "cms",
+                "craft-plugin",
+                "craftcms",
+                "fields",
+                "inventory"
+            ],
+            "time": "2018-07-17T04:50:36+00:00"
+        },
+        {
             "name": "egulias/email-validator",
             "version": "2.1.6",
             "source": {
@@ -1838,17 +1889,6 @@
         {
             "name": "league/uri",
             "version": "5.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/uri.git",
-                "reference": "f2bceb755f1108758cf4cf925e4cd7699ce686aa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/f2bceb755f1108758cf4cf925e4cd7699ce686aa",
-                "reference": "f2bceb755f1108758cf4cf925e4cd7699ce686aa",
-                "shasum": ""
-            },
             "require": {
                 "ext-fileinfo": "*",
                 "ext-intl": "*",
@@ -2660,17 +2700,6 @@
         {
             "name": "roave/security-advisories",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "8605f2e74f558d3e349b219e58414b75b0adc30e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/8605f2e74f558d3e349b219e58414b75b0adc30e",
-                "reference": "8605f2e74f558d3e349b219e58414b75b0adc30e",
-                "shasum": ""
-            },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adodb/adodb-php": "<5.20.12",

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -392,13 +392,13 @@ function getProjectStories($locale, $grantId = null)
     normaliseCacheHeaders();
 
     $criteria = [
-        'section' => 'caseStudies',
+        'section' => 'projectStories',
         'site' => $locale,
-        'status' => 'live',
+        'status' => EntryHelpers::getVersionStatuses(),
     ];
 
     if ($grantId) {
-        $criteria['caseStudyGrantId'] = $grantId;
+        $criteria['grantId'] = $grantId;
     }
 
     return [

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -49,8 +49,6 @@ function getRoutes()
         'homepage',
         'merchandise',
         'news',
-        // @TODO: Remove when launching this section
-        'updates',
     ];
 
     $allowedSectionHandles = array_diff($allSectionHandles, $excludeList);

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -7,6 +7,7 @@ use biglotteryfund\utils\HomepageTransformer;
 use biglotteryfund\utils\Images;
 use biglotteryfund\utils\ListingTransformer;
 use biglotteryfund\utils\PeopleTransformer;
+use biglotteryfund\utils\ProjectStoriesTransformer;
 use biglotteryfund\utils\ResearchTransformer;
 use biglotteryfund\utils\StrategicProgrammeTransformer;
 use biglotteryfund\utils\UpdatesTransformer;
@@ -356,6 +357,7 @@ function getFlexibleContent($locale)
 /**
  * API Endpoint: Get case studies
  * Get a list of summaries for all case studies
+ * @TODO: Deprecate in favour of stories endpoint(s)
  */
 function getCaseStudies($locale, $grantId = null)
 {
@@ -379,6 +381,32 @@ function getCaseStudies($locale, $grantId = null)
         'transformer' => function (Entry $entry) {
             return ContentHelpers::extractCaseStudySummary($entry);
         },
+    ];
+}
+
+/**
+ * Get project stories
+ */
+function getProjectStories($locale, $grantId = null)
+{
+    normaliseCacheHeaders();
+
+    $criteria = [
+        'section' => 'caseStudies',
+        'site' => $locale,
+        'status' => 'live',
+    ];
+
+    if ($grantId) {
+        $criteria['caseStudyGrantId'] = $grantId;
+    }
+
+    return [
+        'serializer' => 'jsonApi',
+        'elementType' => Entry::class,
+        'criteria' => $criteria,
+        'one' => $grantId ? true : false,
+        'transformer' => new ProjectStoriesTransformer($locale),
     ];
 }
 
@@ -600,6 +628,8 @@ return [
         'api/v1/list-routes' => getRoutes,
         'api/v1/<locale:en|cy>/case-studies' => getCaseStudies,
         'api/v1/<locale:en|cy>/case-studies/<grantId>' => getCaseStudies,
+        'api/v1/<locale:en|cy>/project-stories' => getProjectStories,
+        'api/v1/<locale:en|cy>/project-stories/<grantId>' => getProjectStories,
         'api/v2/<locale:en|cy>/funding-programmes' => getFundingProgrammes,
         'api/v2/<locale:en|cy>/funding-programmes/<slug>' => getFundingProgrammes,
         'api/v1/<locale:en|cy>/research' => getResearch,

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -132,6 +132,14 @@ class ContentHelpers
                     ];
                     array_push($parts, $data);
                     break;
+                case 'quote':
+                    $data = [
+                        'type' => $block->type->handle,
+                        'quoteText' => $block->quoteText,
+                        'attribution' => $block->attribution ?? null,
+                    ];
+                    array_push($parts, $data);
+                    break;
                 case 'mediaAside':
                     $data = [
                         'type' => $block->type->handle,

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -4,6 +4,7 @@ namespace biglotteryfund\utils;
 
 use biglotteryfund\utils\ContentHelpers;
 use biglotteryfund\utils\EntryHelpers;
+use biglotteryfund\utils\ProjectStoriesTransformer;
 use craft\elements\Entry;
 use League\Fractal\TransformerAbstract;
 
@@ -56,6 +57,10 @@ class FundingProgrammeTransformer extends TransformerAbstract
             'organisationType' => $entry->organisationType ?? null,
             'legacyPath' => $entry->legacyPath ?? null,
             'caseStudies' => $entry->relatedCaseStudies ? ContentHelpers::extractCaseStudySummaries($entry->relatedCaseStudies->all()) : [],
+            'projectStories' => array_map(function ($entry) {
+                $transformer = new ProjectStoriesTransformer($this->locale);
+                return $transformer->transform($entry);
+            }, $entry->relatedProjectStories ? $entry->relatedProjectStories->all() : [])
         ]);
     }
 }

--- a/lib/ProjectStories.php
+++ b/lib/ProjectStories.php
@@ -13,14 +13,33 @@ class ProjectStoriesTransformer extends TransformerAbstract
         $this->locale = $locale;
     }
 
+    private static function getTrailPhoto($entry)
+    {
+        $hero = Images::extractNewHeroImageField($entry->hero);
+        $heroImage = $hero ? $hero->imageMedium->one() : null;
+        $trailImage = $entry->trailPhoto->one() ?? null;
+
+        $imageSrc = $trailImage ?? $heroImage;
+
+        return $imageSrc ? Images::imgixUrl($imageSrc->url, [
+            'w' => 475,
+            'h' => 320,
+            'crop' => 'faces',
+        ]) : null;
+    }
+
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
         $common = ContentHelpers::getCommonFields($entry, $status, $this->locale);
 
         return array_merge($common, [
-            'grantId' => $entry->caseStudyGrantId ?? null,
+            // @TODO: Move trailSummary and trailPhoto to getCommonFields?
+            'trailSummary' => $entry->trailSummary ?? null,
+            'trailPhoto' => self::getTrailPhoto($entry),
             'content' => ContentHelpers::extractFlexibleContent($entry),
+            'outro' => $entry->outroText ?? null,
+            'grantId' => $entry->grantId ?? null,
         ]);
     }
 }

--- a/lib/ProjectStories.php
+++ b/lib/ProjectStories.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace biglotteryfund\utils;
+
+use biglotteryfund\utils\ContentHelpers;
+use craft\elements\Entry;
+use League\Fractal\TransformerAbstract;
+
+class ProjectStoriesTransformer extends TransformerAbstract
+{
+    public function __construct($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    public function transform(Entry $entry)
+    {
+        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
+        $common = ContentHelpers::getCommonFields($entry, $status, $this->locale);
+
+        return array_merge($common, [
+            'grantId' => $entry->caseStudyGrantId ?? null,
+            'content' => ContentHelpers::extractFlexibleContent($entry),
+        ]);
+    }
+}


### PR DESCRIPTION
- Adds support for a new project stories section
- Adds support for quotes in flexible content

Dependant on the following new fields being added to the CMS:

- [x] Standfirst (`standfirst`)
- [x] Trail summary (`trailSummary`) — A generic version of the `articleSummary` field
- [x] Grant ID (`grantId`) — A generic version of `heroGrantId` and `caseStudyGrantId`
- [x] Related project stories (`relatedProjectStories`)
- [x] New quote block adding to `flexibleContent` with `quoteText` and `attribution` fields