### PR TITLE
Allow URL aliases to have an external URL as opposed to an entry

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -92,11 +92,16 @@ function getAliases($locale)
             'section' => ['aliases'],
         ],
         'transformer' => function (craft\elements\Entry $alias) use ($locale) {
-            $relatedEntry = $alias->relatedEntry->status(['live', 'expired'])->one();
+                $relatedEntry = $alias->relatedEntry->status(['live', 'expired'])->one();
+            if ($relatedEntry) {
+                $uri = EntryHelpers::uriForLocale($relatedEntry->uri, $locale);
+            } else if ($alias->externalUrl) {
+                $uri = $alias->externalUrl;
+            }
             return [
                 'id' => $alias->id,
                 'from' => '/' . $alias->uri,
-                'to' => EntryHelpers::uriForLocale($relatedEntry->uri, $locale),
+                'to' => $uri ?? null,
             ];
         },
     ];

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -92,7 +92,7 @@ function getAliases($locale)
             'section' => ['aliases'],
         ],
         'transformer' => function (craft\elements\Entry $alias) use ($locale) {
-                $relatedEntry = $alias->relatedEntry->status(['live', 'expired'])->one();
+            $relatedEntry = $alias->relatedEntry->status(['live', 'expired'])->one();
             if ($relatedEntry) {
                 $uri = EntryHelpers::uriForLocale($relatedEntry->uri, $locale);
             } else if ($alias->externalUrl) {


### PR DESCRIPTION
This allows the Alias entry type to simply specify a URL to redirect to rather than an entry – useful for redirecting to pages that aren't in the CMS, or even to external pages or files.

Although the field is called `externalUrl`, it can be populated with a relative one (eg. `/funding/programmes`) as it will simply be called inside `res.redirect()`.

This relates to https://github.com/biglotteryfund/blf-alpha/issues/1573 – the list of URLs to import is ready and tested with FeedMe, we just need to import them to the live database (eg. in 2019).