### PR TITLE
Update hero crops

### DIFF
--- a/lib/Images.php
+++ b/lib/Images.php
@@ -5,21 +5,6 @@ namespace biglotteryfund\utils;
 use Imgix\UrlBuilder;
 use League\Uri\Parser;
 
-const IMAGE_SIZES = [
-    'small' => [
-        'w' => '644',
-        'h' => '425',
-    ],
-    'medium' => [
-        'w' => '1280',
-        'h' => '720',
-    ],
-    'large' => [
-        'w' => '1373',
-        'h' => '405',
-    ],
-];
-
 class Images
 {
     private static function _getImgixConfig()
@@ -68,24 +53,6 @@ class Images
         return $image ? $image->url : null;
     }
 
-    public static function getStandardCrops($imageUrl)
-    {
-        return [
-            'small' => self::imgixUrl(
-                $imageUrl,
-                IMAGE_SIZES['small']
-            ),
-            'medium' => self::imgixUrl(
-                $imageUrl,
-                IMAGE_SIZES['medium']
-            ),
-            'large' => self::imgixUrl(
-                $imageUrl,
-                IMAGE_SIZES['large']
-            ),
-        ];
-    }
-
     public static function extractHeroImage($imageField)
     {
         $hero = self::extractImage($imageField);
@@ -96,17 +63,17 @@ class Images
     {
         $imageSmall = self::imgixUrl(
             $heroEntry->imageSmall->one()->url,
-            IMAGE_SIZES['small']
+            ['w' => '644', 'fit' => 'fill']
         );
 
         $imageMedium = self::imgixUrl(
             $heroEntry->imageMedium->one()->url,
-            IMAGE_SIZES['medium']
+            ['w' => '1280', 'fit' => 'fill']
         );
 
         $imageLarge = self::imgixUrl(
             $heroEntry->imageLarge->one()->url,
-            IMAGE_SIZES['large']
+            ['w' => '1373', 'fit' => 'fill']
         );
 
         return [

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -24,7 +24,20 @@ class UpdatesTransformer extends TransformerAbstract
         $extraFields = [
             'promoted' => $entry->articlePromoted,
             'trailPhoto' => Images::extractImageUrl($entry->trailPhoto),
-            'thumbnail' =>  $trailPhotoUrl ? Images::getStandardCrops($trailPhotoUrl) : null,
+            'thumbnail' => $trailPhotoUrl ? [
+                'small' => Images::imgixUrl($trailPhotoUrl, [
+                    'w' => '644',
+                    'h' => '425',
+                ]),
+                'medium' => Images::imgixUrl($trailPhotoUrl, [
+                    'w' => '1280',
+                    'h' => '720',
+                ]),
+                'large' => Images::imgixUrl($trailPhotoUrl, [
+                    'w' => '1373',
+                    'h' => '405',
+                ]),
+            ] : null,
             'category' => $primaryCategory ? ContentHelpers::categorySummary($primaryCategory, $this->locale) : null,
             'authors' => ContentHelpers::getTags($entry->authors->all(), $this->locale),
             'regions' => $entry->regions ? ContentHelpers::nestedCategorySummary($entry->regions->all(), $this->locale) : [],


### PR DESCRIPTION
Update hero crops, inline getStandardCrops into updates transformer.

In order to support new hero images which have a variable height depending on the size of the image we need to switch to `fill` as the resize method https://docs.imgix.com/apis/url/size/fit#fill

This crops the image to the given width but preserves the aspect ratio. As we upload hero images to avoid any actually cropping this results in hero images being output at their original aspect ratio rather than being forced to the aspect ratio defined in code. For hero images this is the behaviour we want.

I've also tested with existing images to confirm that the change doesn't affect how they output.