### PR TITLE
New trail images

### DIFF
--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -181,9 +181,23 @@ class ContentHelpers
     }
 
     // Use custom thumbnail if one is set, otherwise default to hero image.
+    // @TODO: Remove one new hero images are all in place
     public static function getFundingProgrammeThumbnailUrl($entry)
     {
         $heroImage = Images::extractImage($entry->heroImage);
+        $thumbnailSrc = Images::extractImage($entry->trailPhoto) ??
+            ($heroImage ? $heroImage->imageMedium->one() : null);
+        return $thumbnailSrc ? Images::imgixUrl($thumbnailSrc->url, [
+            'w' => 100,
+            'h' => 100,
+            'crop' => 'faces',
+        ]) : null;
+    }
+
+    // Use custom thumbnail if one is set, otherwise default to hero image.
+    public static function getFundingProgrammeThumbnailUrlNew($entry)
+    {
+        $heroImage = Images::extractNewHeroImageField($entry->hero);
         $thumbnailSrc = Images::extractImage($entry->trailPhoto) ??
             ($heroImage ? $heroImage->imageMedium->one() : null);
         return $thumbnailSrc ? Images::imgixUrl($thumbnailSrc->url, [

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -28,7 +28,6 @@ class ContentHelpers
             'hero' => $entry->heroImage ? Images::extractHeroImage($entry->heroImage) : null,
             'heroCredit' => $entry->heroImageCredit ?? null,
             'heroNew' => Images::buildHero($entry->hero),
-            'themeColour' => $entry->themeColour ? $entry->themeColour->value : null,
         ];
     }
 

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -35,6 +35,7 @@ class FundingProgrammeTransformer extends TransformerAbstract
             'description' => $entry->programmeIntro ?? null,
             'footer' => $entry->outroText ?? null,
             'thumbnail' => ContentHelpers::getFundingProgrammeThumbnailUrl($entry),
+            'thumbnailNew' => ContentHelpers::getFundingProgrammeThumbnailUrlNew($entry),
             'trailImage' => self::buildTrailImage($entry->heroImage->one()),
             'trailImageNew' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
             'contentSections' => array_map(function ($block) {

--- a/lib/Images.php
+++ b/lib/Images.php
@@ -102,7 +102,11 @@ class Images
 
     public static function extractNewHeroImageField($heroField)
     {
-        $hero = $heroField->one() ?? null;
-        return $hero ? $hero->image->one() : null;
+        if ($heroField) {
+            $hero = $heroField->one() ?? null;
+            return $hero ? $hero->image->one() : null;
+        } else {
+            return null;
+        }
     }
 }

--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -13,6 +13,14 @@ class ListingTransformer extends TransformerAbstract
         $this->locale = $locale;
     }
 
+    private static function buildTrailImage($imageField)
+    {
+        return $imageField ? Images::imgixUrl(
+            $imageField->imageMedium->one()->url,
+            ['w' => '500', 'h' => '333', 'crop' => 'faces']
+        ) : null;
+    }
+
     private function getRelatedEntries($entry, $relationType)
     {
         $relatedSearch = [];
@@ -52,14 +60,10 @@ class ListingTransformer extends TransformerAbstract
                 $commonFields['linkUrl'] = $customLinkUrl;
             }
 
-            $heroImageField = Images::extractImage($relatedEntry->heroImage);
-
             $relatedEntries[] = array_merge($commonFields, [
-                'photo' => $heroImageField ? Images::imgixUrl($heroImageField->imageSmall->one()->url, [
-                    'w' => 500,
-                    'h' => 333,
-                    'crop' => 'faces',
-                ]) : null,
+                // @TODO: Remove photo in favour of trailImage once all pages have new hero images
+                'photo' => self::buildTrailImage(Images::extractImage($relatedEntry->heroImage)),
+                'trailImage' => self::buildTrailImage(Images::extractNewHeroImageField($relatedEntry->hero)),
             ]);
         }
 

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -13,6 +13,14 @@ class ResearchTransformer extends TransformerAbstract
         $this->locale = $locale;
     }
 
+    private static function buildTrailImage($imageField)
+    {
+        return $imageField ? Images::imgixUrl(
+            $imageField->imageMedium->one()->url,
+            ['w' => '640', 'h' => '360']
+        ) : null;
+    }
+
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
@@ -20,13 +28,10 @@ class ResearchTransformer extends TransformerAbstract
 
         $researchMeta = $entry->researchMeta->one();
 
-        $heroImageField = Images::extractImage($entry->heroImage);
-
         return array_merge($common, [
-            'thumbnail' => $heroImageField ? Images::imgixUrl(
-                $heroImageField->imageMedium->one()->url,
-                ['w' => '640', 'h' => '360']
-            ) : null,
+            // @TODO: Remove thumbnail in favour of trailImage once all pages have new hero images
+            'thumbnail' => self::buildTrailImage(Images::extractImage($entry->heroImage)),
+            'trailImage' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
 
             'introduction' => $entry->introductionText ?? null,
             'contactEmail' => $researchMeta ? $researchMeta->contactEmail : null,
@@ -79,8 +84,8 @@ class ResearchTransformer extends TransformerAbstract
             }, $entry->researchSections->all() ?? []),
 
             'meta' => [
-                'searchScore' => $entry->searchScore ?? null
-            ]
+                'searchScore' => $entry->searchScore ?? null,
+            ],
         ]);
     }
 }

--- a/lib/StrategicProgrammes.php
+++ b/lib/StrategicProgrammes.php
@@ -14,6 +14,14 @@ class StrategicProgrammeTransformer extends TransformerAbstract
         $this->locale = $locale;
     }
 
+    private static function buildTrailImage($imageField)
+    {
+        return $imageField ? Images::imgixUrl(
+            $imageField->imageMedium->one()->url,
+            ['w' => '640', 'h' => '360']
+        ) : null;
+    }
+
     public static function buildSectionBreadcrumbs(Entry $entry, $locale)
     {
         $parentSection = Entry::find()->section('strategicInvestments')->site($locale)->one();
@@ -37,10 +45,9 @@ class StrategicProgrammeTransformer extends TransformerAbstract
             // @TODO: Update template URLs to use linkUrl
             'path' => $commonFields['linkUrl'],
             'sectionBreadcrumbs' => self::buildSectionBreadcrumbs($entry, $this->locale),
-            'thumbnail' => $heroImageField ? Images::imgixUrl(
-                $heroImageField->imageMedium->one()->url,
-                ['w' => '640', 'h' => '360']
-            ) : null,
+            // @TODO: Remove thumbnail in favour of trailImage once all pages have new hero images
+            'thumbnail' => self::buildTrailImage(Images::extractImage($entry->heroImage)),
+            'trailImage' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
             'intro' => $entry->programmeIntro,
             'aims' => $entry->strategicProgrammeAims,
             'impact' => array_map(function ($block) {

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -49,7 +49,6 @@ class UpdatesTransformer extends TransformerAbstract
                     'title' => $programme->title,
                     'linkUrl' => $programme->externalUrl ? $programme->externalUrl : EntryHelpers::uriForLocale($programme->uri, $this->locale),
                     'intro' => $programme->programmeIntro,
-                    'photo' => Images::extractHeroImage($programme->heroImage),
                     'thumbnail' => ContentHelpers::getFundingProgrammeThumbnailUrl($programme),
                 ];
             }, $entry->relatedFundingProgrammes->all() ?? []),

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -50,6 +50,7 @@ class UpdatesTransformer extends TransformerAbstract
                     'linkUrl' => $programme->externalUrl ? $programme->externalUrl : EntryHelpers::uriForLocale($programme->uri, $this->locale),
                     'intro' => $programme->programmeIntro,
                     'thumbnail' => ContentHelpers::getFundingProgrammeThumbnailUrl($programme),
+                    'thumbnailNew' => ContentHelpers::getFundingProgrammeThumbnailUrlNew($programme),
                 ];
             }, $entry->relatedFundingProgrammes->all() ?? []),
             'updateType' => [


### PR DESCRIPTION
Add support for new hero images in trail images.

Where transformers were using a misleading `thumbnail` or `photo` property, I've standardised on `trailImage` for the new images.