### PR TITLE
Use small source image for trail image crops on listings

### DIFF
--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -16,7 +16,7 @@ class ListingTransformer extends TransformerAbstract
     private static function buildTrailImage($imageField)
     {
         return $imageField ? Images::imgixUrl(
-            $imageField->imageMedium->one()->url,
+            $imageField->imageSmall->one()->url,
             ['w' => '500', 'h' => '333', 'crop' => 'faces']
         ) : null;
     }


### PR DESCRIPTION
Use small source image for trail image crops on listings. Especially for new style hero images this results in a much better crop across the board and avoids us needing to create custom trail images.