### PR TITLE
Add Google Analytics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "ether/tags": "^1.0",
     "doublesecretagency/craft-inventory": "^2.0",
     "charliedev/element-map": "^1.2",
-    "vardump/recentchanges": "^1.1"
+    "vardump/recentchanges": "^1.1",
+    "doublesecretagency/craft-cpjs": "^2.1"
   },
   "autoload" : {
     "psr-4" : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fdc158951594b28c794cb5bce51238d",
+    "content-hash": "36d1733f005a12185b9a260d0000c167",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1123,6 +1123,57 @@
                 "parser"
             ],
             "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "doublesecretagency/craft-cpjs",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doublesecretagency/craft-cpjs.git",
+                "reference": "c8cdb87b0361362162c97981494038b3d8595407"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doublesecretagency/craft-cpjs/zipball/c8cdb87b0361362162c97981494038b3d8595407",
+                "reference": "c8cdb87b0361362162c97981494038b3d8595407",
+                "shasum": ""
+            },
+            "require": {
+                "craftcms/cms": "^3.0.0-RC1"
+            },
+            "type": "craft-plugin",
+            "extra": {
+                "name": "Control Panel JS",
+                "handle": "cp-js",
+                "schemaVersion": "2.0.0",
+                "changelogUrl": "https://raw.githubusercontent.com/doublesecretagency/craft-cpjs/v2/CHANGELOG.md",
+                "class": "doublesecretagency\\cpjs\\CpJs"
+            },
+            "autoload": {
+                "psr-4": {
+                    "doublesecretagency\\cpjs\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Double Secret Agency",
+                    "homepage": "https://www.doublesecretagency.com/plugins"
+                }
+            ],
+            "description": "Add custom JavaScript to your Control Panel.",
+            "keywords": [
+                "Craft",
+                "cms",
+                "cp-js",
+                "craft-plugin",
+                "craftcms",
+                "javascript"
+            ],
+            "time": "2018-01-01T22:58:51+00:00"
         },
         {
             "name": "doublesecretagency/craft-inventory",

--- a/config/cp-js.php
+++ b/config/cp-js.php
@@ -1,0 +1,10 @@
+<?php
+return [
+    '*' => [],
+    'test' => [
+        'jsFile' => '/resources/js/analytics.test.js',
+    ],
+    'production' => [
+        'jsFile' => '/resources/js/analytics.js',
+    ]
+];

--- a/web/resources/js/analytics.js
+++ b/web/resources/js/analytics.js
@@ -1,0 +1,13 @@
+var ref = window.document.getElementsByTagName('script')[0];
+var script = window.document.createElement('script');
+script.src = 'https://www.googletagmanager.com/gtag/js?id=UA-637620-33';
+ref.parentNode.insertBefore(script, ref);
+
+window.dataLayer = window.dataLayer || [];
+
+function gtag() {
+    dataLayer.push(arguments);
+}
+
+gtag('js', new Date());
+gtag('config', 'UA-637620-33');

--- a/web/resources/js/analytics.js
+++ b/web/resources/js/analytics.js
@@ -1,13 +1,10 @@
+window.ga = window.ga || function () {
+    (ga.q = ga.q || []).push(arguments)
+};
+ga.l = +new Date();
+ga('create', 'UA-637620-33', 'auto');
+ga('send', 'pageview');
 var ref = window.document.getElementsByTagName('script')[0];
 var script = window.document.createElement('script');
-script.src = 'https://www.googletagmanager.com/gtag/js?id=UA-637620-33';
+script.src = 'https://www.google-analytics.com/analytics.js';
 ref.parentNode.insertBefore(script, ref);
-
-window.dataLayer = window.dataLayer || [];
-
-function gtag() {
-    dataLayer.push(arguments);
-}
-
-gtag('js', new Date());
-gtag('config', 'UA-637620-33');

--- a/web/resources/js/analytics.test.js
+++ b/web/resources/js/analytics.test.js
@@ -1,0 +1,13 @@
+var ref = window.document.getElementsByTagName('script')[0];
+var script = window.document.createElement('script');
+script.src = 'https://www.googletagmanager.com/gtag/js?id=UA-98908627-2';
+ref.parentNode.insertBefore(script, ref);
+
+window.dataLayer = window.dataLayer || [];
+
+function gtag() {
+    dataLayer.push(arguments);
+}
+
+gtag('js', new Date());
+gtag('config', 'UA-98908627-2');

--- a/web/resources/js/analytics.test.js
+++ b/web/resources/js/analytics.test.js
@@ -1,13 +1,10 @@
+window.ga = window.ga || function () {
+    (ga.q = ga.q || []).push(arguments)
+};
+ga.l = +new Date();
+ga('create', 'UA-98908627-2', 'auto');
+ga('send', 'pageview');
 var ref = window.document.getElementsByTagName('script')[0];
 var script = window.document.createElement('script');
-script.src = 'https://www.googletagmanager.com/gtag/js?id=UA-98908627-2';
+script.src = 'https://www.google-analytics.com/analytics.js';
 ref.parentNode.insertBefore(script, ref);
-
-window.dataLayer = window.dataLayer || [];
-
-function gtag() {
-    dataLayer.push(arguments);
-}
-
-gtag('js', new Date());
-gtag('config', 'UA-98908627-2');


### PR DESCRIPTION
This is a little out of curiosity but I think it'll be useful for us to see how the CMS is being used.

This uses @davidrapson's suggesting about the admin panel JS plugin to load in a per-environment config. It's a little funky compared to Google's copy-and-paste tracker as it's JS-only (so has to manually load what would normally be a separate `<script>` tag), but the file it's loading is meant to be `async` anyway so it works well (have tested locally). 