### PR TITLE
Modify homepage endpoint to return selection of featured links

### DIFF
--- a/lib/Homepage.php
+++ b/lib/Homepage.php
@@ -12,51 +12,25 @@ class HomepageTransformer extends TransformerAbstract
         $this->locale = $locale;
     }
 
-    private static function buildHomepageHero($hero)
+    private static function buildHomepageLinks($links)
     {
-        $defaults = ['lossless' => true, 'q' => 90];
-
-        $imageSmall = Images::imgixUrl(
-            $hero->imageSmall->one()->url,
-            array_replace_recursive($defaults, ['w' => '644', 'h' => '573'])
-        );
-
-        $imageMedium = Images::imgixUrl(
-            $hero->imageMedium->one()->url,
-            array_replace_recursive($defaults, ['w' => '1280', 'h' => '720'])
-        );
-
-        $imageLarge = Images::imgixUrl(
-            $hero->imageLarge->one()->url,
-            array_replace_recursive($defaults, ['w' => '1373', 'h' => '505'])
-        );
-
-        $result = [
-            'caption' => $hero->caption,
-            'default' => $imageMedium,
-            'small' => $imageSmall,
-            'medium' => $imageMedium,
-            'large' => $imageLarge,
-        ];
-
-        if ($hero->captionFootnote) {
-            $result['captionFootnote'] = $hero->captionFootnote;
+        $parts = [];
+        foreach ($links as $link) {
+            $data = [
+                'label' => $link->linkText,
+                'href' => $link->linkUrl,
+                'image' => Images::extractHeroImage($link->heroImage),
+            ];
+            array_push($parts, $data);
         }
-
-        return $result;
+        return $parts;
     }
 
     public function transform(Entry $entry)
     {
         return [
             'id' => $entry->id,
-            'heroImages' => [
-                'default' => self::buildHomepageHero($entry->homepageHeroImages->one()),
-                'candidates' => array_map(
-                    'self::buildHomepageHero',
-                    $entry->homepageHeroImages->all() ?? []
-                )
-            ],
+            'featuredLinks' => self::buildHomepageLinks($entry->featuredLinks->all()),
         ];
     }
 }


### PR DESCRIPTION
This tweaks the homepage single to have a matrix field like this:

![image](https://user-images.githubusercontent.com/394376/52267056-f446e780-292f-11e9-8bd8-ea89b0e89bc8.png)

This allows us to construct a list of "featured links" for the homepage.

I've already added the fields to the live CMS, and once this is out we can safely delete the (now unused) hero image field that's already there.

Pairs with https://github.com/biglotteryfund/blf-alpha/pull/1734