### PR TITLE
Fix a few instances where we assume an image field exists

### DIFF
--- a/lib/Images.php
+++ b/lib/Images.php
@@ -43,13 +43,13 @@ class Images
 
     public static function extractImage($imageField)
     {
-        $image = $imageField->one();
+        $image = $imageField ? $imageField->one() : null;
         return $image ?? null;
     }
 
     public static function extractImageUrl($imageField)
     {
-        $image = $imageField->one();
+        $image = $imageField ? $imageField->one() : null;
         return $image ? $image->url : null;
     }
 


### PR DESCRIPTION
Prevents an issue where a linked entry (in this case, a strategic programme without a trail image) becomes unpreviewable because we're assuming a `trailPhoto` is there, when that field doesn't exist for Strategics (should it?).