### PR TITLE
Add support for research documents as well as pages

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -274,7 +274,10 @@ function getResearch($locale, $type = false)
         if ($tagQuery = \Craft::$app->request->getParam('tag')) {
             $activeTag = Tag::find()->group('tags')->slug($tagQuery)->site($locale)->one();
             if ($activeTag) {
-                $meta['activeTag'] = ContentHelpers::tagSummary($activeTag, $locale);
+                $meta['activeTag'] = [
+                    'label' => $activeTag->title,
+                    'value' => $activeTag->slug
+                ];
                 $elementsToRelateTo[] = [
                     'targetElement' => $activeTag,
                 ];

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -218,19 +218,18 @@ function getResearch($locale, $type = false)
         'type' => ($type === 'documents') ? 'researchDocument' : 'research'
     ];
 
-    if ($searchQuery = \Craft::$app->request->getParam('q')) {
+    $sortParam = \Craft::$app->request->getParam('sort');
+    if ($searchQuery = \Craft::$app->request->getParam('q') && $sortParam === 'score') {
         $criteria['orderBy'] = 'score';
         $criteria['search'] = [
             'query' => $searchQuery,
             'subLeft' => true,
             'subRight' => true,
         ];
-    } else if ($sortQuery = \Craft::$app->request->getParam('sort')) {
-        if ($sortQuery === 'newest') {
-            $criteria['orderBy'] = 'postDate desc';
-        } else if ($sortQuery === 'oldest') {
-            $criteria['orderBy'] = 'postDate asc';
-        }
+    } else if ($sortParam === 'newest') {
+        $criteria['orderBy'] = 'postDate desc';
+    } else if ($sortParam === 'oldest') {
+        $criteria['orderBy'] = 'postDate asc';
     }
 
     // Document-specific search query fields

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -9,6 +9,7 @@ use biglotteryfund\utils\ListingTransformer;
 use biglotteryfund\utils\PeopleTransformer;
 use biglotteryfund\utils\ProjectStoriesTransformer;
 use biglotteryfund\utils\ResearchTransformer;
+use biglotteryfund\utils\ResearchDocumentTransformer;
 use biglotteryfund\utils\StrategicProgrammeTransformer;
 use biglotteryfund\utils\UpdatesTransformer;
 use craft\elements\Category;
@@ -211,6 +212,8 @@ function getResearch($locale, $type = false)
 {
     normaliseCacheHeaders();
 
+    $transformer = $type === 'documents' ? new ResearchDocumentTransformer($locale) : new ResearchTransformer($locale);
+
     $criteria = [
         'site' => $locale,
         'section' => 'research',
@@ -342,7 +345,7 @@ function getResearch($locale, $type = false)
         'elementType' => Entry::class,
         'criteria' => $criteria,
         'meta' => $meta ?? null,
-        'transformer' => new ResearchTransformer($locale),
+        'transformer' => $transformer,
     ];
 }
 

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -219,7 +219,7 @@ function getResearch($locale, $type = false)
     ];
 
     $sortParam = \Craft::$app->request->getParam('sort');
-    if ($searchQuery = \Craft::$app->request->getParam('q') && $sortParam === 'score') {
+    if ($searchQuery = \Craft::$app->request->getParam('q') && ($sortParam === 'score' || !$sortParam)) {
         $criteria['orderBy'] = 'score';
         $criteria['search'] = [
             'query' => $searchQuery,

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -4041,13 +4041,6 @@ sections:
                     sortOrder: 1
                 name: Aliases
                 sortOrder: 1
-              -
-                fields:
-                  e5ca4911-ec90-44e6-8349-34361a8da221:
-                    required: false
-                    sortOrder: 1
-                name: 'Delete Me'
-                sortOrder: 2
         handle: aliases
         hasTitleField: false
         name: Aliases

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -30,21 +30,21 @@ categoryGroups:
       maxLevels: '2'
       uid: 8e25c90a-f458-4a3c-89b8-2e044cd75c35
   8c0e1bff-9968-4082-8e67-11cf77d01c3f:
-    name: "Insight Document Type\t"
     handle: insightDocumentType
-    structure:
-      uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-      maxLevels: '1'
+    name: "Insight Document Type\t"
     siteSettings:
       81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
         hasUrls: false
-        uriFormat: null
         template: null
+        uriFormat: null
       d0635f95-a563-4f66-9195-33da0eb644d5:
         hasUrls: false
-        uriFormat: null
         template: null
-dateModified: 1553603461
+        uriFormat: null
+    structure:
+      maxLevels: '1'
+      uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
+dateModified: 1553766544
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -61,6 +61,8 @@ email:
 fieldGroups:
   1770279d-fae8-42d7-9209-2e4e311f9e8a:
     name: 'Content Page'
+  24b26cf1-ecc7-44ee-a2d5-0f1de62055cf:
+    name: 'Insight Document'
   2a71faea-4942-4260-b0ee-df0303fc29e9:
     name: Author
   381bc7ef-8175-4392-a114-07f68c9a1b9a:
@@ -73,6 +75,8 @@ fieldGroups:
     name: Research
   9a6de417-cda1-486f-9022-b8c5387f751e:
     name: 'Funding Programmes'
+  a9adb8e8-0825-43f9-8f1a-862323940637:
+    name: 'Social Media'
   e3237b61-2fe0-45f7-9036-c1ff7a7975e8:
     name: Data
   f0f968ce-8ae3-4607-9e2f-c7d06f196869:
@@ -81,10 +85,6 @@ fieldGroups:
     name: Homepage
   fe37f91c-b0e2-482c-8482-05d9b335ce86:
     name: Merchandise
-  a9adb8e8-0825-43f9-8f1a-862323940637:
-    name: 'Social Media'
-  24b26cf1-ecc7-44ee-a2d5-0f1de62055cf:
-    name: 'Insight Document'
 fields:
   02eb210a-8b09-489c-994d-009c27b6167b:
     contentColumnType: string
@@ -141,6 +141,40 @@ fields:
     translationKeyFormat: null
     translationMethod: site
     type: craft\fields\Matrix
+  0bab8639-49a8-4bf6-aff7-5ffe60e2bab8:
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+    handle: document
+    instructions: 'Upload the file here'
+    name: Document
+    searchable: false
+    settings:
+      allowedKinds:
+        - compressed
+        - excel
+        - html
+        - image
+        - pdf
+        - powerpoint
+        - text
+        - video
+        - word
+      defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+      defaultUploadLocationSubpath: ''
+      limit: '1'
+      localizeRelations: ''
+      restrictFiles: ''
+      selectionLabel: ''
+      singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+      singleUploadLocationSubpath: insights/documents
+      source: null
+      sources: '*'
+      targetSiteId: null
+      useSingleFolder: '1'
+      viewMode: list
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\Assets
   0cec86e6-ee99-4992-95ee-4044be2efd17:
     contentColumnType: text
     fieldGroup: f0f968ce-8ae3-4607-9e2f-c7d06f196869
@@ -387,6 +421,24 @@ fields:
     translationKeyFormat: null
     translationMethod: site
     type: craft\fields\Assets
+  3544eb2e-dd0a-4c86-9474-692a074b6802:
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+    handle: documentTags
+    instructions: 'Add some keywords to help people find this document (eg. "Volunteering", "Loneliness", "Youth employment" etc)'
+    name: Tags
+    searchable: true
+    settings:
+      limit: null
+      localizeRelations: ''
+      selectionLabel: ''
+      source: 'taggroup:7e74a4e5-2144-4421-8176-8d66e57f0a3e'
+      sources: '*'
+      targetSiteId: null
+      viewMode: null
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\Tags
   3690189e-73a1-4880-aea8-8b326f364617:
     contentColumnType: string
     fieldGroup: f34fff60-41cf-47f6-8fe9-3146ae2a95b1
@@ -419,6 +471,25 @@ fields:
     translationKeyFormat: null
     translationMethod: language
     type: craft\fields\PlainText
+  3d1305a6-366b-4a1d-8849-433df83a803e:
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+    handle: relatedInsightsPage
+    instructions: 'If this document relates to an existing Insights page, choose it here and a link will be displayed.'
+    name: 'Related Insights page'
+    searchable: false
+    settings:
+      limit: '1'
+      localizeRelations: ''
+      selectionLabel: ''
+      source: null
+      sources:
+        - 'section:3102e285-face-4513-b17e-2d3b046fcc88'
+      targetSiteId: null
+      viewMode: null
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\Entries
   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
     contentColumnType: string
     fieldGroup: 1770279d-fae8-42d7-9209-2e4e311f9e8a
@@ -540,6 +611,26 @@ fields:
     translationKeyFormat: null
     translationMethod: language
     type: craft\redactor\Field
+  5024077b-fccb-4164-8874-8fd05a936e13:
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+    handle: programme
+    instructions: 'Choose a funding programme that this research relates to'
+    name: Programme
+    searchable: false
+    settings:
+      limit: ''
+      localizeRelations: '1'
+      selectionLabel: 'Choose a programme'
+      source: null
+      sources:
+        - 'section:2b1f6da1-20e9-4176-a181-7ab073fab8f9'
+        - 'section:f273edc9-ecad-4a33-857d-75410b9480e5'
+      targetSiteId: null
+      viewMode: null
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\Entries
   54f67d9c-5b73-4bb0-85e6-ca6d9949e03c:
     contentColumnType: text
     fieldGroup: f0f968ce-8ae3-4607-9e2f-c7d06f196869
@@ -603,6 +694,23 @@ fields:
     translationKeyFormat: null
     translationMethod: site
     type: craft\fields\Matrix
+  60a339d6-ca4b-48a2-9e48-6c2bbe582b0e:
+    contentColumnType: text
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+    handle: summary
+    instructions: 'A couple of sentences to summarise the content of this document'
+    name: Summary
+    searchable: true
+    settings:
+      charLimit: ''
+      code: ''
+      columnType: text
+      initialRows: '4'
+      multiline: ''
+      placeholder: ''
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\PlainText
   61aca7e9-75e9-4610-a0b5-39bb844a68c1:
     contentColumnType: text
     fieldGroup: 381bc7ef-8175-4392-a114-07f68c9a1b9a
@@ -638,6 +746,38 @@ fields:
     translationKeyFormat: null
     translationMethod: site
     type: craft\redactor\Field
+  69bcf1c5-c1e1-45db-b20f-76643d1751de:
+    contentColumnType: text
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+    handle: partnershipName
+    instructions: 'Add the name of the group or programme this document was produced in partnership with'
+    name: 'Partnership Name'
+    searchable: true
+    settings:
+      charLimit: ''
+      code: ''
+      columnType: text
+      initialRows: '4'
+      multiline: ''
+      placeholder: ''
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\PlainText
+  6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
+    contentColumnType: string
+    fieldGroup: a9adb8e8-0825-43f9-8f1a-862323940637
+    handle: socialMediaTags
+    instructions: 'Add some Open Graph metadata which displays when this content is shared on social media (eg. Twitter and Facebook cards)'
+    name: 'Social Media Tags'
+    searchable: false
+    settings:
+      contentTable: '{{%matrixcontent_socialmediatags}}'
+      localizeBlocks: '1'
+      maxBlocks: ''
+      minBlocks: ''
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\Matrix
   6c792519-1c25-4194-a0e5-60377539e790:
     contentColumnType: string
     fieldGroup: 1770279d-fae8-42d7-9209-2e4e311f9e8a
@@ -669,6 +809,25 @@ fields:
     translationKeyFormat: null
     translationMethod: none
     type: craft\fields\Dropdown
+  6ffbb157-9d66-4994-8a8f-947c35960c2d:
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+    handle: portfolio
+    instructions: 'Which funding portfolio location does this document relate to?'
+    name: Portfolio
+    searchable: false
+    settings:
+      branchLimit: '1'
+      limit: null
+      localizeRelations: ''
+      selectionLabel: 'Choose a portfolio'
+      source: 'group:83f5331d-3367-4856-ab4c-acf5d2725b10'
+      sources: '*'
+      targetSiteId: null
+      viewMode: null
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\Categories
   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
     contentColumnType: text
     fieldGroup: 1770279d-fae8-42d7-9209-2e4e311f9e8a
@@ -1496,6 +1655,25 @@ fields:
     translationKeyFormat: null
     translationMethod: site
     type: craft\fields\Categories
+  ebcd4aaf-83ff-48e4-9f0d-8a7e22313652:
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+    handle: documentType
+    instructions: 'What kind of document this is'
+    name: 'Document Type'
+    searchable: true
+    settings:
+      branchLimit: '1'
+      limit: null
+      localizeRelations: ''
+      selectionLabel: 'Choose a document type'
+      source: 'group:8c0e1bff-9968-4082-8e67-11cf77d01c3f'
+      sources: '*'
+      targetSiteId: null
+      viewMode: null
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\Categories
   ee5ad666-8266-45cc-9852-f681a7db300f:
     contentColumnType: string
     fieldGroup: 9a6de417-cda1-486f-9022-b8c5387f751e
@@ -1532,6 +1710,23 @@ fields:
     translationKeyFormat: null
     translationMethod: none
     type: craft\fields\Dropdown
+  f91f1b44-ef7d-4f91-8d75-75ad6ae3a677:
+    contentColumnType: text
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+    handle: publisher
+    instructions: 'The name of the publisher of this document, eg. "The National Lottery Community Fund" or "Anna Freud".'
+    name: Publisher
+    searchable: true
+    settings:
+      charLimit: ''
+      code: ''
+      columnType: text
+      initialRows: '4'
+      multiline: ''
+      placeholder: ''
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\PlainText
   f946d578-25d4-40b3-a68b-f04068f34a17:
     contentColumnType: text
     fieldGroup: 8ac2452c-d4dd-43fd-bca8-f8b24bec856f
@@ -1602,182 +1797,6 @@ fields:
     translationKeyFormat: null
     translationMethod: none
     type: craft\fields\PlainText
-  6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
-    name: 'Social Media Tags'
-    handle: socialMediaTags
-    instructions: 'Add some Open Graph metadata which displays when this content is shared on social media (eg. Twitter and Facebook cards)'
-    searchable: false
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\Matrix
-    settings:
-      minBlocks: ''
-      maxBlocks: ''
-      contentTable: '{{%matrixcontent_socialmediatags}}'
-      localizeBlocks: '1'
-    contentColumnType: string
-    fieldGroup: a9adb8e8-0825-43f9-8f1a-862323940637
-  5024077b-fccb-4164-8874-8fd05a936e13:
-    name: Programme
-    handle: programme
-    instructions: 'Choose a funding programme that this research relates to'
-    searchable: false
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\Entries
-    settings:
-      sources:
-        - 'section:2b1f6da1-20e9-4176-a181-7ab073fab8f9'
-        - 'section:f273edc9-ecad-4a33-857d-75410b9480e5'
-      source: null
-      targetSiteId: null
-      viewMode: null
-      limit: ''
-      selectionLabel: 'Choose a programme'
-      localizeRelations: '1'
-    contentColumnType: string
-    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
-  60a339d6-ca4b-48a2-9e48-6c2bbe582b0e:
-    name: Summary
-    handle: summary
-    instructions: 'A couple of sentences to summarise the content of this document'
-    searchable: true
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\PlainText
-    settings:
-      placeholder: ''
-      code: ''
-      multiline: ''
-      initialRows: '4'
-      charLimit: ''
-      columnType: text
-    contentColumnType: text
-    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
-  f91f1b44-ef7d-4f91-8d75-75ad6ae3a677:
-    name: Publisher
-    handle: publisher
-    instructions: 'The name of the publisher of this document, eg. "The National Lottery Community Fund" or "Anna Freud".'
-    searchable: true
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\PlainText
-    settings:
-      placeholder: ''
-      code: ''
-      multiline: ''
-      initialRows: '4'
-      charLimit: ''
-      columnType: text
-    contentColumnType: text
-    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
-  ebcd4aaf-83ff-48e4-9f0d-8a7e22313652:
-    name: 'Document Type'
-    handle: documentType
-    instructions: 'What kind of document this is'
-    searchable: true
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\Categories
-    settings:
-      branchLimit: '1'
-      sources: '*'
-      source: 'group:8c0e1bff-9968-4082-8e67-11cf77d01c3f'
-      targetSiteId: null
-      viewMode: null
-      limit: null
-      selectionLabel: 'Choose a document type'
-      localizeRelations: ''
-    contentColumnType: string
-    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
-  6ffbb157-9d66-4994-8a8f-947c35960c2d:
-    name: Portfolio
-    handle: portfolio
-    instructions: 'Which funding portfolio location does this document relate to?'
-    searchable: false
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\Categories
-    settings:
-      branchLimit: '1'
-      sources: '*'
-      source: 'group:83f5331d-3367-4856-ab4c-acf5d2725b10'
-      targetSiteId: null
-      viewMode: null
-      limit: null
-      selectionLabel: 'Choose a portfolio'
-      localizeRelations: ''
-    contentColumnType: string
-    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
-  0bab8639-49a8-4bf6-aff7-5ffe60e2bab8:
-    name: Document
-    handle: document
-    instructions: 'Upload the file here'
-    searchable: false
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\Assets
-    settings:
-      useSingleFolder: '1'
-      defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-      defaultUploadLocationSubpath: ''
-      singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-      singleUploadLocationSubpath: insights/documents
-      restrictFiles: ''
-      allowedKinds:
-        - compressed
-        - excel
-        - html
-        - image
-        - pdf
-        - powerpoint
-        - text
-        - video
-        - word
-      sources: '*'
-      source: null
-      targetSiteId: null
-      viewMode: list
-      limit: '1'
-      selectionLabel: ''
-      localizeRelations: ''
-    contentColumnType: string
-    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
-  3544eb2e-dd0a-4c86-9474-692a074b6802:
-    name: Tags
-    handle: documentTags
-    instructions: 'Add some keywords to help people find this document (eg. "Volunteering", "Loneliness", "Youth employment" etc)'
-    searchable: true
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\Tags
-    settings:
-      sources: '*'
-      source: 'taggroup:7e74a4e5-2144-4421-8176-8d66e57f0a3e'
-      targetSiteId: null
-      viewMode: null
-      limit: null
-      selectionLabel: ''
-      localizeRelations: ''
-    contentColumnType: string
-    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
-  69bcf1c5-c1e1-45db-b20f-76643d1751de:
-    name: 'Partnership Name'
-    handle: partnershipName
-    instructions: 'Add the name of the group or programme this document was produced in partnership with'
-    searchable: true
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\PlainText
-    settings:
-      placeholder: ''
-      code: ''
-      multiline: ''
-      initialRows: '4'
-      charLimit: ''
-      columnType: text
-    contentColumnType: text
-    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
 imageTransforms:
   02af4884-899c-46bf-9add-6bfac4b267c8:
     format: null
@@ -2933,6 +2952,137 @@ matrixBlockTypes:
     handle: contentArea
     name: 'Content Area'
     sortOrder: '1'
+  cdf38474-7e76-4140-aecb-1e2962f2a9b7:
+    field: 6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51
+    fieldLayouts:
+      df689c5d-a020-4ec2-971f-ca2cd8f5c1b1:
+        tabs:
+          -
+            fields:
+              10b1092c-6186-4d57-825b-29af4519292d:
+                required: '0'
+                sortOrder: 2
+              313a413e-2758-4963-8abf-7ae418034c90:
+                required: '0'
+                sortOrder: 3
+              34c79cfe-a250-4f37-9db7-09538f105c74:
+                required: '0'
+                sortOrder: 1
+              c147383b-5f6d-449c-9120-0ac3da15a85f:
+                required: '0'
+                sortOrder: 5
+              d0c63510-508c-48bf-8cf2-20b02e9682f7:
+                required: '0'
+                sortOrder: 4
+            name: Content
+            sortOrder: 1
+    fields:
+      10b1092c-6186-4d57-825b-29af4519292d:
+        contentColumnType: text
+        fieldGroup: null
+        handle: ogDescription
+        instructions: 'A brief description of the content, usually between 2 and 4 sentences. This will displayed below the title of the post on Facebook.'
+        name: Description
+        searchable: '1'
+        settings:
+          charLimit: ''
+          code: ''
+          columnType: text
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      313a413e-2758-4963-8abf-7ae418034c90:
+        contentColumnType: string
+        fieldGroup: null
+        handle: ogFacebookImage
+        instructions: "• Open Graph Stories – Images appear in a square format. Image ratios for these apps should be 600 x 600 px.\r\n• Non-open Graph Stories – Images appear in a rectangular format. You should use a 1.91:1 image ratio, such as 600 x 314 px."
+        name: 'Facebook Image'
+        searchable: '1'
+        settings:
+          allowedKinds:
+            - image
+          defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          defaultUploadLocationSubpath: ''
+          limit: '1'
+          localizeRelations: ''
+          restrictFiles: '1'
+          selectionLabel: ''
+          singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          singleUploadLocationSubpath: social/facebook
+          source: null
+          sources: '*'
+          targetSiteId: null
+          useSingleFolder: '1'
+          viewMode: list
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\Assets
+      34c79cfe-a250-4f37-9db7-09538f105c74:
+        contentColumnType: text
+        fieldGroup: null
+        handle: ogTitle
+        instructions: "The title of this article without any branding (such as our site name). If left blank, the current entry title will be used.\r\n"
+        name: Title
+        searchable: '1'
+        settings:
+          charLimit: ''
+          code: ''
+          columnType: text
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      c147383b-5f6d-449c-9120-0ac3da15a85f:
+        contentColumnType: text
+        fieldGroup: null
+        handle: ogSlug
+        instructions: 'Optional – if you specify this then only a unique URL (eg. ?social=<slug>) will show these social media assets.'
+        name: Slug
+        searchable: '1'
+        settings:
+          charLimit: ''
+          code: ''
+          columnType: text
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      d0c63510-508c-48bf-8cf2-20b02e9682f7:
+        contentColumnType: string
+        fieldGroup: null
+        handle: ogTwitterImage
+        instructions: "• Images for Twitter Cards support an aspect ratio of 2:1 with minimum dimensions of 300x157 or maximum of 4096x4096 pixels.\r\n• Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported."
+        name: 'Twitter Image'
+        searchable: '1'
+        settings:
+          allowedKinds:
+            - image
+          defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          defaultUploadLocationSubpath: ''
+          limit: '1'
+          localizeRelations: ''
+          restrictFiles: '1'
+          selectionLabel: ''
+          singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          singleUploadLocationSubpath: social/twitter
+          source: null
+          sources: '*'
+          targetSiteId: null
+          useSingleFolder: '1'
+          viewMode: list
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\Assets
+    handle: openGraphTags
+    name: 'Open Graph Tags'
+    sortOrder: 1
   d0984ff1-7885-4dff-b648-3af3e222ade9:
     field: 093b4dc3-16d8-439a-a963-39b9c9d7c164
     fieldLayouts:
@@ -3418,137 +3568,6 @@ matrixBlockTypes:
     handle: product
     name: Product
     sortOrder: '1'
-  cdf38474-7e76-4140-aecb-1e2962f2a9b7:
-    field: 6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51
-    name: 'Open Graph Tags'
-    handle: openGraphTags
-    sortOrder: 1
-    fields:
-      34c79cfe-a250-4f37-9db7-09538f105c74:
-        name: Title
-        handle: ogTitle
-        instructions: "The title of this article without any branding (such as our site name). If left blank, the current entry title will be used.\r\n"
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\PlainText
-        settings:
-          placeholder: ''
-          code: ''
-          multiline: ''
-          initialRows: '4'
-          charLimit: ''
-          columnType: text
-        contentColumnType: text
-        fieldGroup: null
-      10b1092c-6186-4d57-825b-29af4519292d:
-        name: Description
-        handle: ogDescription
-        instructions: 'A brief description of the content, usually between 2 and 4 sentences. This will displayed below the title of the post on Facebook.'
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\PlainText
-        settings:
-          placeholder: ''
-          code: ''
-          multiline: ''
-          initialRows: '4'
-          charLimit: ''
-          columnType: text
-        contentColumnType: text
-        fieldGroup: null
-      313a413e-2758-4963-8abf-7ae418034c90:
-        name: 'Facebook Image'
-        handle: ogFacebookImage
-        instructions: "• Open Graph Stories – Images appear in a square format. Image ratios for these apps should be 600 x 600 px.\r\n• Non-open Graph Stories – Images appear in a rectangular format. You should use a 1.91:1 image ratio, such as 600 x 314 px."
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\Assets
-        settings:
-          useSingleFolder: '1'
-          defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-          defaultUploadLocationSubpath: ''
-          singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-          singleUploadLocationSubpath: social/facebook
-          restrictFiles: '1'
-          allowedKinds:
-            - image
-          sources: '*'
-          source: null
-          targetSiteId: null
-          viewMode: list
-          limit: '1'
-          selectionLabel: ''
-          localizeRelations: ''
-        contentColumnType: string
-        fieldGroup: null
-      d0c63510-508c-48bf-8cf2-20b02e9682f7:
-        name: 'Twitter Image'
-        handle: ogTwitterImage
-        instructions: "• Images for Twitter Cards support an aspect ratio of 2:1 with minimum dimensions of 300x157 or maximum of 4096x4096 pixels.\r\n• Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported."
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\Assets
-        settings:
-          useSingleFolder: '1'
-          defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-          defaultUploadLocationSubpath: ''
-          singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-          singleUploadLocationSubpath: social/twitter
-          restrictFiles: '1'
-          allowedKinds:
-            - image
-          sources: '*'
-          source: null
-          targetSiteId: null
-          viewMode: list
-          limit: '1'
-          selectionLabel: ''
-          localizeRelations: ''
-        contentColumnType: string
-        fieldGroup: null
-      c147383b-5f6d-449c-9120-0ac3da15a85f:
-        name: Slug
-        handle: ogSlug
-        instructions: 'Optional – if you specify this then only a unique URL (eg. ?social=<slug>) will show these social media assets.'
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\PlainText
-        settings:
-          placeholder: ''
-          code: ''
-          multiline: ''
-          initialRows: '4'
-          charLimit: ''
-          columnType: text
-        contentColumnType: text
-        fieldGroup: null
-    fieldLayouts:
-      df689c5d-a020-4ec2-971f-ca2cd8f5c1b1:
-        tabs:
-          -
-            name: Content
-            sortOrder: 1
-            fields:
-              34c79cfe-a250-4f37-9db7-09538f105c74:
-                required: false
-                sortOrder: 1
-              10b1092c-6186-4d57-825b-29af4519292d:
-                required: false
-                sortOrder: 2
-              313a413e-2758-4963-8abf-7ae418034c90:
-                required: false
-                sortOrder: 3
-              d0c63510-508c-48bf-8cf2-20b02e9682f7:
-                required: false
-                sortOrder: 4
-              c147383b-5f6d-449c-9120-0ac3da15a85f:
-                required: false
-                sortOrder: 5
 plugins:
   aws-s3:
     enabled: '1'
@@ -3634,38 +3653,38 @@ sections:
     enableVersioning: '1'
     entryTypes:
       6cefbe41-9224-4ce3-94bd-740423659c18:
-        name: 'Building Better Opportunities'
-        handle: buildingBetterOpportunities
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           3dbd0510-0cfc-4a98-8dd2-1d78a606c7f6:
             tabs:
               -
-                name: 'Content Page'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
+                  0ffe78fe-8cab-4c76-a558-5dcb3cb2dd34:
                     required: false
-                    sortOrder: 1
+                    sortOrder: 4
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: true
                     sortOrder: 3
-                  0ffe78fe-8cab-4c76-a558-5dcb3cb2dd34:
+                  99eaaae9-87e0-4b54-a247-504431915423:
                     required: false
-                    sortOrder: 4
+                    sortOrder: 1
+                name: 'Content Page'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: buildingBetterOpportunities
+        hasTitleField: true
+        name: 'Building Better Opportunities'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: buildingBetterOpportunities
     name: 'Building Better Opportunities'
     propagateEntries: '1'
@@ -3683,41 +3702,41 @@ sections:
     enableVersioning: '1'
     entryTypes:
       9147c461-7eef-4d50-af6e-474010b5a504:
-        name: Jobs
-        handle: jobs
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           465ad913-dff2-4ca8-bfb1-408cfcaf83e9:
             tabs:
               -
-                name: 'Jobs page content'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 3
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 4
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 5
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: 'Jobs page content'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: jobs
+        hasTitleField: true
+        name: Jobs
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: jobs
     name: Jobs
     propagateEntries: '1'
@@ -3734,105 +3753,105 @@ sections:
         uriFormat: jobs
     type: single
   2b1f6da1-20e9-4176-a181-7ab073fab8f9:
-    name: 'Funding Programmes'
-    handle: fundingProgrammes
-    type: structure
     enableVersioning: true
-    propagateEntries: true
-    siteSettings:
-      81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
-        enabledByDefault: true
-        hasUrls: true
-        uriFormat: 'funding/programmes/{slug}'
-        template: funding-programs/_entry
-      d0635f95-a563-4f66-9195-33da0eb644d5:
-        enabledByDefault: true
-        hasUrls: true
-        uriFormat: 'funding/programmes/{slug}'
-        template: funding-programs/_entry
-    structure:
-      uid: 570b86f8-ad2e-487e-b501-2c14f616844a
-      maxLevels: '1'
     entryTypes:
       79c88f21-da56-48db-9e1c-ec15618ca38f:
-        name: 'Funding Programmes'
-        handle: fundingProgrammes
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           96266c61-497d-41b4-9e92-9b62178dbf1b:
             tabs:
               -
-                name: 'Programme Details'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
-                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
-                    required: false
-                    sortOrder: 2
-                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
-                    required: false
-                    sortOrder: 3
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
-                    required: false
-                    sortOrder: 4
-                  bcbf9339-ab42-4e3f-9db7-eaf3b499d36c:
-                    required: false
-                    sortOrder: 5
                   03ed24af-07b1-42c3-875e-98050e9560c7:
                     required: false
                     sortOrder: 6
+                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
+                    required: false
+                    sortOrder: 3
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 7
-              -
-                name: 'Programme Summary'
-                sortOrder: 2
-                fields:
-                  5899dcd7-1384-49e0-98a5-633b44fa05c0:
+                  99eaaae9-87e0-4b54-a247-504431915423:
                     required: false
                     sortOrder: 1
-                  b1cb76e6-64d2-41f8-837d-089907b480c6:
+                  bcbf9339-ab42-4e3f-9db7-eaf3b499d36c:
+                    required: false
+                    sortOrder: 5
+                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
                     required: false
                     sortOrder: 2
-                  650ff388-625b-4f42-82bd-10a96d6b47b1:
-                    required: false
-                    sortOrder: 3
-                  ee5ad666-8266-45cc-9852-f681a7db300f:
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
                     required: false
                     sortOrder: 4
+                name: 'Programme Details'
+                sortOrder: 1
+              -
+                fields:
                   0db131ea-69e3-4c13-955d-b607df3c9959:
                     required: false
                     sortOrder: 5
-                  8d3adb13-80ec-4b1a-9524-7b23bafb6c60:
-                    required: false
-                    sortOrder: 6
-                  c2f8265a-898e-4f67-abf9-45dabc783f7e:
-                    required: false
-                    sortOrder: 7
-                  9af6d5eb-9e64-473d-b1c3-5642ec2ead05:
-                    required: false
-                    sortOrder: 8
                   1338f3a8-bad4-4e23-a0f0-327be8f16e60:
                     required: false
                     sortOrder: 9
                   46d0352f-42af-4d63-be4d-9c9df54c5871:
                     required: false
                     sortOrder: 10
+                  5899dcd7-1384-49e0-98a5-633b44fa05c0:
+                    required: false
+                    sortOrder: 1
+                  650ff388-625b-4f42-82bd-10a96d6b47b1:
+                    required: false
+                    sortOrder: 3
+                  8d3adb13-80ec-4b1a-9524-7b23bafb6c60:
+                    required: false
+                    sortOrder: 6
+                  9af6d5eb-9e64-473d-b1c3-5642ec2ead05:
+                    required: false
+                    sortOrder: 8
+                  b1cb76e6-64d2-41f8-837d-089907b480c6:
+                    required: false
+                    sortOrder: 2
+                  c2f8265a-898e-4f67-abf9-45dabc783f7e:
+                    required: false
+                    sortOrder: 7
                   e5147d7e-c0d3-4cb2-92cf-3b5e5eae96e6:
                     required: false
                     sortOrder: 11
+                  ee5ad666-8266-45cc-9852-f681a7db300f:
+                    required: false
+                    sortOrder: 4
+                name: 'Programme Summary'
+                sortOrder: 2
               -
-                name: 'Social Media'
-                sortOrder: 3
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 3
+        handle: fundingProgrammes
+        hasTitleField: true
+        name: 'Funding Programmes'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
+    handle: fundingProgrammes
+    name: 'Funding Programmes'
+    propagateEntries: true
+    siteSettings:
+      81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
+        enabledByDefault: true
+        hasUrls: true
+        template: funding-programs/_entry
+        uriFormat: 'funding/programmes/{slug}'
+      d0635f95-a563-4f66-9195-33da0eb644d5:
+        enabledByDefault: true
+        hasUrls: true
+        template: funding-programs/_entry
+        uriFormat: 'funding/programmes/{slug}'
+    structure:
+      maxLevels: '1'
+      uid: 570b86f8-ad2e-487e-b501-2c14f616844a
+    type: structure
   2b255d19-d30b-4d89-8555-cddcd1eb945e:
     enableVersioning: '1'
     entryTypes:
@@ -3875,98 +3894,101 @@ sections:
     enableVersioning: '1'
     entryTypes:
       803ebe88-78a2-4e00-8b3c-a8649ffb61ce:
-        name: Research
-        handle: research
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           148090b7-1887-40f5-a00e-8d90a513eb77:
             tabs:
               -
-                name: 'Main content'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: true
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 4
                   4b573749-5271-405a-9d27-9e086ee1f31f:
                     required: false
                     sortOrder: 5
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 4
                   83a59f94-8342-417f-b427-11c3c162d89e:
                     required: true
                     sortOrder: 6
-              -
-                name: 'Related content'
-                sortOrder: 2
-                fields:
-                  d152a0b3-b09f-4b2c-a7a6-605b9a0fed17:
-                    required: false
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
                     sortOrder: 1
-                  f946d578-25d4-40b3-a68b-f04068f34a17:
-                    required: false
-                    sortOrder: 2
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: true
+                    sortOrder: 3
+                name: 'Main content'
+                sortOrder: 1
+              -
+                fields:
                   585a68f7-bb7c-4d7f-9acf-10f9b2107243:
                     required: true
                     sortOrder: 3
                   7a4edc2b-a06d-4baf-a33f-da76742cbf35:
                     required: false
                     sortOrder: 4
+                  d152a0b3-b09f-4b2c-a7a6-605b9a0fed17:
+                    required: false
+                    sortOrder: 1
+                  f946d578-25d4-40b3-a68b-f04068f34a17:
+                    required: false
+                    sortOrder: 2
+                name: 'Related content'
+                sortOrder: 2
               -
-                name: 'Social Media'
-                sortOrder: 3
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
-      e22437bd-941b-4079-9b02-4f37c5b41ea9:
-        name: Document
-        handle: researchDocument
+                name: 'Social Media'
+                sortOrder: 3
+        handle: research
         hasTitleField: true
-        titleLabel: Title
+        name: Research
+        sortOrder: 1
         titleFormat: ''
-        sortOrder: 2
+        titleLabel: Title
+      e22437bd-941b-4079-9b02-4f37c5b41ea9:
         fieldLayouts:
           8185a6ba-3549-4be6-92c2-3cd81f83275f:
             tabs:
               -
-                name: 'Insight Document'
-                sortOrder: 1
                 fields:
-                  60a339d6-ca4b-48a2-9e48-6c2bbe582b0e:
-                    required: true
-                    sortOrder: 1
-                  5024077b-fccb-4164-8874-8fd05a936e13:
-                    required: true
-                    sortOrder: 2
-                  6ffbb157-9d66-4994-8a8f-947c35960c2d:
-                    required: false
-                    sortOrder: 3
-                  69bcf1c5-c1e1-45db-b20f-76643d1751de:
-                    required: false
-                    sortOrder: 4
-                  ebcd4aaf-83ff-48e4-9f0d-8a7e22313652:
-                    required: true
-                    sortOrder: 5
                   0bab8639-49a8-4bf6-aff7-5ffe60e2bab8:
                     required: true
                     sortOrder: 6
-                  f91f1b44-ef7d-4f91-8d75-75ad6ae3a677:
-                    required: false
-                    sortOrder: 7
                   3544eb2e-dd0a-4c86-9474-692a074b6802:
                     required: true
                     sortOrder: 8
+                  3d1305a6-366b-4a1d-8849-433df83a803e:
+                    required: false
+                    sortOrder: 9
+                  5024077b-fccb-4164-8874-8fd05a936e13:
+                    required: true
+                    sortOrder: 2
+                  60a339d6-ca4b-48a2-9e48-6c2bbe582b0e:
+                    required: true
+                    sortOrder: 1
+                  69bcf1c5-c1e1-45db-b20f-76643d1751de:
+                    required: false
+                    sortOrder: 4
+                  6ffbb157-9d66-4994-8a8f-947c35960c2d:
+                    required: false
+                    sortOrder: 3
+                  ebcd4aaf-83ff-48e4-9f0d-8a7e22313652:
+                    required: true
+                    sortOrder: 5
+                  f91f1b44-ef7d-4f91-8d75-75ad6ae3a677:
+                    required: false
+                    sortOrder: 7
+                name: 'Insight Document'
+                sortOrder: 1
+        handle: researchDocument
+        hasTitleField: true
+        name: Document
+        sortOrder: 2
+        titleFormat: ''
+        titleLabel: Title
     handle: research
     name: Insights
     propagateEntries: '1'
@@ -3986,32 +4008,32 @@ sections:
     enableVersioning: '1'
     entryTypes:
       a11f990c-b6b9-4887-bfc3-5aaca8b7c3c0:
-        name: Aliases
-        handle: aliases
-        hasTitleField: false
-        titleLabel: ''
-        titleFormat: '{slug}'
-        sortOrder: 1
         fieldLayouts:
           fda6063b-17f6-4bd4-b0eb-42fdcf0031ef:
             tabs:
               -
-                name: Aliases
-                sortOrder: 1
                 fields:
-                  adfb9aa8-ae2e-4b0e-9068-1a58c62105b0:
-                    required: false
-                    sortOrder: 1
                   02eb210a-8b09-489c-994d-009c27b6167b:
                     required: false
                     sortOrder: 2
+                  adfb9aa8-ae2e-4b0e-9068-1a58c62105b0:
+                    required: false
+                    sortOrder: 1
+                name: Aliases
+                sortOrder: 1
               -
-                name: 'Delete Me'
-                sortOrder: 2
                 fields:
                   e5ca4911-ec90-44e6-8349-34361a8da221:
                     required: false
                     sortOrder: 1
+                name: 'Delete Me'
+                sortOrder: 2
+        handle: aliases
+        hasTitleField: false
+        name: Aliases
+        sortOrder: 1
+        titleFormat: '{slug}'
+        titleLabel: ''
     handle: aliases
     name: Aliases
     propagateEntries: '0'
@@ -4031,158 +4053,158 @@ sections:
     enableVersioning: '1'
     entryTypes:
       16b4a64e-3a41-41d6-9cb0-abbb0b37773f:
-        name: 'News article'
-        handle: updates
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 2
         fieldLayouts:
           6ccb5707-3d48-45e4-83a9-8baed98aac34:
             tabs:
               -
-                name: 'Article content'
-                sortOrder: 1
                 fields:
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: false
-                    sortOrder: 1
                   1b339885-ec9d-4871-852a-6ab021977805:
                     required: false
                     sortOrder: 2
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
-                    required: false
-                    sortOrder: 3
-                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
-                    required: false
-                    sortOrder: 4
-                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
-                    required: false
-                    sortOrder: 5
+                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
+                    required: true
+                    sortOrder: 8
                   419ecf2d-b6f9-4754-a309-88579895b504:
                     required: false
                     sortOrder: 6
                   7a4edc2b-a06d-4baf-a33f-da76742cbf35:
                     required: false
                     sortOrder: 7
-                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
-                    required: true
-                    sortOrder: 8
+                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
+                    required: false
+                    sortOrder: 5
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: false
+                    sortOrder: 1
+                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
+                    required: false
+                    sortOrder: 4
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                    required: false
+                    sortOrder: 3
+                name: 'Article content'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
-      af57c0a7-4c55-470e-9331-03fc4c25b6f9:
-        name: Blogpost
-        handle: blog
+                name: 'Social Media'
+                sortOrder: 2
+        handle: updates
         hasTitleField: true
-        titleLabel: Title
+        name: 'News article'
+        sortOrder: 2
         titleFormat: ''
-        sortOrder: 3
+        titleLabel: Title
+      af57c0a7-4c55-470e-9331-03fc4c25b6f9:
         fieldLayouts:
           cd1b7bf5-abb9-4d14-aa3c-a4cbfdfe88fe:
             tabs:
               -
-                name: 'Blog post'
-                sortOrder: 1
                 fields:
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: false
-                    sortOrder: 1
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
-                    required: false
-                    sortOrder: 2
-                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
-                    required: false
-                    sortOrder: 3
+                  0cfefd57-0c56-49da-921e-dd45bf0146a8:
+                    required: true
+                    sortOrder: 6
                   1b339885-ec9d-4871-852a-6ab021977805:
                     required: false
                     sortOrder: 4
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: true
                     sortOrder: 5
-                  0cfefd57-0c56-49da-921e-dd45bf0146a8:
-                    required: true
-                    sortOrder: 6
                   419ecf2d-b6f9-4754-a309-88579895b504:
                     required: false
                     sortOrder: 7
-                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
-                    required: false
-                    sortOrder: 8
                   7a4edc2b-a06d-4baf-a33f-da76742cbf35:
                     required: false
                     sortOrder: 9
+                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
+                    required: false
+                    sortOrder: 3
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: false
+                    sortOrder: 1
+                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
+                    required: false
+                    sortOrder: 8
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                    required: false
+                    sortOrder: 2
+                name: 'Blog post'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
-      c9f7e8cb-c731-4f5f-8f52-41611666b3a5:
-        name: 'Press Release'
-        handle: press_releases
+                name: 'Social Media'
+                sortOrder: 2
+        handle: blog
         hasTitleField: true
-        titleLabel: Title
+        name: Blogpost
+        sortOrder: 3
         titleFormat: ''
-        sortOrder: 1
+        titleLabel: Title
+      c9f7e8cb-c731-4f5f-8f52-41611666b3a5:
         fieldLayouts:
           331affbf-f1ba-4a26-a8cb-7d21de2435c5:
             tabs:
               -
-                name: 'Press Release'
-                sortOrder: 1
                 fields:
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                  18a9853a-8570-41b5-9be5-89b09f045a67:
                     required: false
-                    sortOrder: 1
+                    sortOrder: 10
                   1b339885-ec9d-4871-852a-6ab021977805:
                     required: false
                     sortOrder: 2
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                  25308ee1-088a-4b07-83df-c7100eab536e:
                     required: false
-                    sortOrder: 3
-                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
+                    sortOrder: 12
+                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: false
-                    sortOrder: 4
-                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
-                    required: false
-                    sortOrder: 5
+                    sortOrder: 9
                   419ecf2d-b6f9-4754-a309-88579895b504:
                     required: false
                     sortOrder: 6
                   7a4edc2b-a06d-4baf-a33f-da76742cbf35:
                     required: false
                     sortOrder: 7
-                  ea2c21db-5b6a-43db-adf0-299005c96e09:
-                    required: true
-                    sortOrder: 8
-                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
+                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
                     required: false
-                    sortOrder: 9
-                  18a9853a-8570-41b5-9be5-89b09f045a67:
+                    sortOrder: 5
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
                     required: false
-                    sortOrder: 10
-                  fb58a355-aa74-4216-b874-3c723f101d50:
-                    required: false
-                    sortOrder: 11
-                  25308ee1-088a-4b07-83df-c7100eab536e:
-                    required: false
-                    sortOrder: 12
+                    sortOrder: 1
                   de9ed6f6-ee49-45c7-a685-cf952a498f91:
                     required: false
                     sortOrder: 13
+                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
+                    required: false
+                    sortOrder: 4
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                    required: false
+                    sortOrder: 3
+                  ea2c21db-5b6a-43db-adf0-299005c96e09:
+                    required: true
+                    sortOrder: 8
+                  fb58a355-aa74-4216-b874-3c723f101d50:
+                    required: false
+                    sortOrder: 11
+                name: 'Press Release'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: press_releases
+        hasTitleField: true
+        name: 'Press Release'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: updates
     name: Updates
     propagateEntries: '1'
@@ -4202,38 +4224,38 @@ sections:
     enableVersioning: '1'
     entryTypes:
       32545da5-c0fa-45f7-90c9-5ebc1eb2079c:
-        name: Merchandise
-        handle: merchandise
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           caed816f-70b3-4340-b299-61181fa28f49:
             tabs:
               -
-                name: Merchandise
-                sortOrder: 1
                 fields:
-                  db0b8702-ef1b-409c-aa55-6de9d41d4d4a:
-                    required: false
-                    sortOrder: 1
-                  ce51477f-1fbc-4c51-a482-621384b56698:
-                    required: true
-                    sortOrder: 2
-                  e2c780b8-c133-4e69-af2f-cee1076275cd:
-                    required: true
-                    sortOrder: 3
                   85937a58-39af-479b-b64b-283999b877df:
                     required: false
                     sortOrder: 4
+                  ce51477f-1fbc-4c51-a482-621384b56698:
+                    required: true
+                    sortOrder: 2
+                  db0b8702-ef1b-409c-aa55-6de9d41d4d4a:
+                    required: false
+                    sortOrder: 1
+                  e2c780b8-c133-4e69-af2f-cee1076275cd:
+                    required: true
+                    sortOrder: 3
+                name: Merchandise
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: merchandise
+        hasTitleField: true
+        name: Merchandise
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: merchandise
     name: Merchandise
     propagateEntries: '1'
@@ -4256,41 +4278,41 @@ sections:
     enableVersioning: '1'
     entryTypes:
       3d29509c-9184-412b-902c-4628e3a3be5e:
-        name: Benefits
-        handle: benefits
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           c994ea54-d2b6-4f64-99b8-0b12898af37a:
             tabs:
               -
-                name: 'Benefits page content'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 3
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 4
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 5
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: 'Benefits page content'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: benefits
+        hasTitleField: true
+        name: Benefits
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: benefits
     name: Benefits
     propagateEntries: '1'
@@ -4310,44 +4332,44 @@ sections:
     enableVersioning: '1'
     entryTypes:
       b7d863c4-671d-492f-aba9-396925eff937:
-        name: Contact
-        handle: contact
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           df332a3d-7b02-4a23-bf98-f6328b7baaa0:
             tabs:
               -
-                name: 'Content Page'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: false
-                    sortOrder: 4
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 5
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 6
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: false
+                    sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: 'Content Page'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: contact
+        hasTitleField: true
+        name: Contact
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: contact
     name: Contact
     propagateEntries: '1'
@@ -4367,50 +4389,50 @@ sections:
     enableVersioning: '1'
     entryTypes:
       a0b8bcd6-c5a7-4c25-aad8-9fa8bdd9eca6:
-        name: 'Funding Guidance'
-        handle: fundingGuidance
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           79b47f10-cb80-4fb4-83a9-9b43d49de47b:
             tabs:
               -
-                name: Content
-                sortOrder: 1
                 fields:
-                  4bbbad71-25c1-4e25-9b13-8815cee1ee98:
-                    required: false
-                    sortOrder: 1
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: false
-                    sortOrder: 2
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 3
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 4
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                  4bbbad71-25c1-4e25-9b13-8815cee1ee98:
                     required: false
-                    sortOrder: 5
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 6
+                    sortOrder: 1
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 7
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 8
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 6
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 5
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: false
+                    sortOrder: 3
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: false
+                    sortOrder: 2
+                name: Content
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: fundingGuidance
+        hasTitleField: true
+        name: 'Funding Guidance'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: fundingGuidance
     name: 'Funding Guidance'
     propagateEntries: '1'
@@ -4433,47 +4455,47 @@ sections:
     enableVersioning: '1'
     entryTypes:
       3da0ca80-59b6-41e8-87c8-3658d9d2c3ea:
-        name: 'Project Stories'
-        handle: projectStories
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           e69e408d-fe6c-4f2d-bf36-2fce1836fbfa:
             tabs:
               -
-                name: 'Project story'
-                sortOrder: 1
                 fields:
-                  77ee3d71-5f00-486d-8593-1eea1a6e8cb4:
-                    required: false
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
-                    required: false
-                    sortOrder: 3
                   3b6db079-d2fc-4d40-b8d6-010fd64c8895:
                     required: false
                     sortOrder: 4
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: true
                     sortOrder: 5
-                  7234b38a-a7fc-4fbb-840f-c277d57f1ced:
-                    required: false
-                    sortOrder: 6
                   61aca7e9-75e9-4610-a0b5-39bb844a68c1:
                     required: true
                     sortOrder: 7
+                  7234b38a-a7fc-4fbb-840f-c277d57f1ced:
+                    required: false
+                    sortOrder: 6
+                  77ee3d71-5f00-486d-8593-1eea1a6e8cb4:
+                    required: false
+                    sortOrder: 1
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                    required: false
+                    sortOrder: 3
+                name: 'Project story'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: projectStories
+        hasTitleField: true
+        name: 'Project Stories'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: projectStories
     name: 'Project Stories'
     propagateEntries: '1'
@@ -4493,42 +4515,42 @@ sections:
     enableVersioning: '1'
     entryTypes:
       8f0f28b7-5dd3-4eb9-a71e-1e3f286f8085:
-        name: 'Our People'
-        handle: people
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           711fc888-e548-493d-8917-4bea84002fee:
             tabs:
               -
-                name: People
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
                   8c779db5-d5b9-4669-bb16-7749b921bc9b:
                     required: true
                     sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: People
+                sortOrder: 1
               -
-                name: Documents
-                sortOrder: 2
                 fields:
                   25308ee1-088a-4b07-83df-c7100eab536e:
                     required: false
                     sortOrder: 1
+                name: Documents
+                sortOrder: 2
               -
-                name: 'Social Media'
-                sortOrder: 3
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 3
+        handle: people
+        hasTitleField: true
+        name: 'Our People'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: people
     name: 'Our People'
     propagateEntries: '1'
@@ -4551,56 +4573,56 @@ sections:
     enableVersioning: '1'
     entryTypes:
       62073583-fc93-4b16-9081-a4d281bf6826:
-        name: 'Case Studies'
-        handle: caseStudies
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           1ae40b04-73c4-4578-b564-9cfbe42aaad1:
             tabs:
               -
-                name: 'Case Study'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
-                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
-                    required: false
-                    sortOrder: 2
-                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
-                    required: false
-                    sortOrder: 3
-                  ddea1520-060a-494e-95aa-f667a0f513e2:
-                    required: false
-                    sortOrder: 4
-                  ccddec99-6800-4547-afb4-022b00cf4915:
-                    required: true
-                    sortOrder: 5
-                  54f67d9c-5b73-4bb0-85e6-ca6d9949e03c:
-                    required: false
-                    sortOrder: 6
                   0cec86e6-ee99-4992-95ee-4044be2efd17:
                     required: true
                     sortOrder: 7
+                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
+                    required: false
+                    sortOrder: 3
                   1d64b0db-e29d-4232-b025-ff4793117dd8:
                     required: false
                     sortOrder: 8
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: false
                     sortOrder: 9
+                  54f67d9c-5b73-4bb0-85e6-ca6d9949e03c:
+                    required: false
+                    sortOrder: 6
                   8e813e66-eb51-4945-ba7b-013aa7d8b7d2:
                     required: false
                     sortOrder: 10
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: false
+                    sortOrder: 1
+                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
+                    required: false
+                    sortOrder: 2
+                  ccddec99-6800-4547-afb4-022b00cf4915:
+                    required: true
+                    sortOrder: 5
+                  ddea1520-060a-494e-95aa-f667a0f513e2:
+                    required: false
+                    sortOrder: 4
+                name: 'Case Study'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: caseStudies
+        hasTitleField: true
+        name: 'Case Studies'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: caseStudies
     name: 'Case Studies'
     propagateEntries: '1'
@@ -4620,38 +4642,38 @@ sections:
     enableVersioning: '1'
     entryTypes:
       8f2097a4-3a5d-4d38-9c35-b7a713c8758d:
-        name: 'About landing page'
-        handle: aboutLandingPage
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           f464d738-3a07-4b54-add6-d44116434ee2:
             tabs:
               -
-                name: About
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: true
                     sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: About
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: aboutLandingPage
+        hasTitleField: true
+        name: 'About landing page'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: aboutLandingPage
     name: 'About landing page'
     propagateEntries: '1'
@@ -4671,18 +4693,10 @@ sections:
     enableVersioning: '1'
     entryTypes:
       ca2c914a-7b86-4e18-885d-339d868d24d9:
-        name: Data
-        handle: data
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           fb473c93-ca03-4a7b-bc3f-06026d23fd5c:
             tabs:
               -
-                name: Data
-                sortOrder: 1
                 fields:
                   093b4dc3-16d8-439a-a963-39b9c9d7c164:
                     required: true
@@ -4690,13 +4704,21 @@ sections:
                   b1a844c2-594c-4e72-8523-a911d7b80f24:
                     required: true
                     sortOrder: 2
+                name: Data
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: data
+        hasTitleField: true
+        name: Data
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: data
     name: Data
     propagateEntries: '1'
@@ -4716,44 +4738,44 @@ sections:
     enableVersioning: '1'
     entryTypes:
       9b5463bd-6bf4-4da9-a732-56e3b5375b77:
-        name: 'Strategic investments in England'
-        handle: strategicInvestments
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           2e584ee6-1524-424c-abbf-2fd255b5f938:
             tabs:
               -
-                name: Content
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 4
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 5
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 6
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: false
+                    sortOrder: 1
+                name: Content
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: strategicInvestments
+        hasTitleField: true
+        name: 'Strategic investments in England'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: strategicInvestments
     name: 'Strategic investments in England'
     propagateEntries: '1'
@@ -4773,47 +4795,47 @@ sections:
     enableVersioning: '1'
     entryTypes:
       1320c236-b94a-4d47-aa7d-68a2aece2c01:
-        name: About
-        handle: about
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           82e54392-e2bd-4e3c-aa03-2c003082b499:
             tabs:
               -
-                name: 'Content Page'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: true
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 4
+                  46d0352f-42af-4d63-be4d-9c9df54c5871:
+                    required: false
+                    sortOrder: 7
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 5
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 6
-                  46d0352f-42af-4d63-be4d-9c9df54c5871:
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: true
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
                     required: false
-                    sortOrder: 7
+                    sortOrder: 1
+                name: 'Content Page'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: about
+        hasTitleField: true
+        name: About
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: about
     name: About
     propagateEntries: '1'
@@ -4865,44 +4887,44 @@ sections:
         titleFormat: null
         titleLabel: Title
       214caa6b-a341-4d7c-902d-7441c99c07ce:
-        name: 'Customer Service'
-        handle: customerService
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           948a33aa-c0ad-4dad-97bc-16bd549f184f:
             tabs:
               -
-                name: 'Content Page'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 4
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 5
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 6
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: false
+                    sortOrder: 1
+                name: 'Content Page'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: customerService
+        hasTitleField: true
+        name: 'Customer Service'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: customerService
     name: 'Customer Service'
     propagateEntries: '1'
@@ -4975,74 +4997,74 @@ sections:
     enableVersioning: '1'
     entryTypes:
       0a2d1a91-96ae-4fba-867f-62699822b0c6:
-        name: 'Strategic Programmes'
-        handle: strategicProgrammes
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           8c2af0ed-5678-420f-a3a8-4c1d9a7ea622:
             tabs:
               -
-                name: Common
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
-                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
-                    required: false
-                    sortOrder: 2
-                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
-                    required: false
-                    sortOrder: 3
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: true
-                    sortOrder: 4
-                  bcbf9339-ab42-4e3f-9db7-eaf3b499d36c:
-                    required: false
-                    sortOrder: 5
                   02eb210a-8b09-489c-994d-009c27b6167b:
                     required: false
                     sortOrder: 6
-              -
-                name: 'Aims & Learning'
-                sortOrder: 2
-                fields:
-                  dbfb641b-23fa-4110-969e-32cae11e39a9:
+                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
                     required: false
                     sortOrder: 1
+                  bcbf9339-ab42-4e3f-9db7-eaf3b499d36c:
+                    required: false
+                    sortOrder: 5
+                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
+                    required: false
+                    sortOrder: 2
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: true
+                    sortOrder: 4
+                name: Common
+                sortOrder: 1
+              -
+                fields:
                   607006ca-1479-43a1-9889-7ee63ef60289:
                     required: false
                     sortOrder: 2
-              -
-                name: Partners
-                sortOrder: 3
-                fields:
-                  4d5d77c6-2596-4418-85e9-822f7d1c7f67:
+                  dbfb641b-23fa-4110-969e-32cae11e39a9:
                     required: false
                     sortOrder: 1
+                name: 'Aims & Learning'
+                sortOrder: 2
+              -
+                fields:
                   065e680b-ad85-42eb-a1b2-6623e8233466:
                     required: false
                     sortOrder: 2
+                  4d5d77c6-2596-4418-85e9-822f7d1c7f67:
+                    required: false
+                    sortOrder: 1
                   7d911d3c-651d-4c2c-ae62-a64b0f554bb0:
                     required: false
                     sortOrder: 3
+                name: Partners
+                sortOrder: 3
               -
-                name: Resources
-                sortOrder: 4
                 fields:
                   816a3589-836c-4201-9d84-8d77a93a52a8:
                     required: false
                     sortOrder: 1
+                name: Resources
+                sortOrder: 4
               -
-                name: 'Social Media'
-                sortOrder: 5
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 5
+        handle: strategicProgrammes
+        hasTitleField: true
+        name: 'Strategic Programmes'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: strategicProgrammes
     name: 'Strategic Programmes'
     propagateEntries: '1'

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -29,7 +29,22 @@ categoryGroups:
     structure:
       maxLevels: '2'
       uid: 8e25c90a-f458-4a3c-89b8-2e044cd75c35
-dateModified: 1553531104
+  8c0e1bff-9968-4082-8e67-11cf77d01c3f:
+    name: "Insight Document Type\t"
+    handle: insightDocumentType
+    structure:
+      uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
+      maxLevels: '1'
+    siteSettings:
+      81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
+        hasUrls: false
+        uriFormat: null
+        template: null
+      d0635f95-a563-4f66-9195-33da0eb644d5:
+        hasUrls: false
+        uriFormat: null
+        template: null
+dateModified: 1553603461
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -68,6 +83,8 @@ fieldGroups:
     name: Merchandise
   a9adb8e8-0825-43f9-8f1a-862323940637:
     name: 'Social Media'
+  24b26cf1-ecc7-44ee-a2d5-0f1de62055cf:
+    name: 'Insight Document'
 fields:
   02eb210a-8b09-489c-994d-009c27b6167b:
     contentColumnType: string
@@ -1600,6 +1617,167 @@ fields:
       localizeBlocks: '1'
     contentColumnType: string
     fieldGroup: a9adb8e8-0825-43f9-8f1a-862323940637
+  5024077b-fccb-4164-8874-8fd05a936e13:
+    name: Programme
+    handle: programme
+    instructions: 'Choose a funding programme that this research relates to'
+    searchable: false
+    translationMethod: site
+    translationKeyFormat: null
+    type: craft\fields\Entries
+    settings:
+      sources:
+        - 'section:2b1f6da1-20e9-4176-a181-7ab073fab8f9'
+        - 'section:f273edc9-ecad-4a33-857d-75410b9480e5'
+      source: null
+      targetSiteId: null
+      viewMode: null
+      limit: ''
+      selectionLabel: 'Choose a programme'
+      localizeRelations: '1'
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+  60a339d6-ca4b-48a2-9e48-6c2bbe582b0e:
+    name: Summary
+    handle: summary
+    instructions: 'A couple of sentences to summarise the content of this document'
+    searchable: true
+    translationMethod: site
+    translationKeyFormat: null
+    type: craft\fields\PlainText
+    settings:
+      placeholder: ''
+      code: ''
+      multiline: ''
+      initialRows: '4'
+      charLimit: ''
+      columnType: text
+    contentColumnType: text
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+  f91f1b44-ef7d-4f91-8d75-75ad6ae3a677:
+    name: Publisher
+    handle: publisher
+    instructions: 'The name of the publisher of this document, eg. "The National Lottery Community Fund" or "Anna Freud".'
+    searchable: true
+    translationMethod: site
+    translationKeyFormat: null
+    type: craft\fields\PlainText
+    settings:
+      placeholder: ''
+      code: ''
+      multiline: ''
+      initialRows: '4'
+      charLimit: ''
+      columnType: text
+    contentColumnType: text
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+  ebcd4aaf-83ff-48e4-9f0d-8a7e22313652:
+    name: 'Document Type'
+    handle: documentType
+    instructions: 'What kind of document this is'
+    searchable: true
+    translationMethod: site
+    translationKeyFormat: null
+    type: craft\fields\Categories
+    settings:
+      branchLimit: '1'
+      sources: '*'
+      source: 'group:8c0e1bff-9968-4082-8e67-11cf77d01c3f'
+      targetSiteId: null
+      viewMode: null
+      limit: null
+      selectionLabel: 'Choose a document type'
+      localizeRelations: ''
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+  6ffbb157-9d66-4994-8a8f-947c35960c2d:
+    name: Portfolio
+    handle: portfolio
+    instructions: 'Which funding portfolio location does this document relate to?'
+    searchable: false
+    translationMethod: site
+    translationKeyFormat: null
+    type: craft\fields\Categories
+    settings:
+      branchLimit: '1'
+      sources: '*'
+      source: 'group:83f5331d-3367-4856-ab4c-acf5d2725b10'
+      targetSiteId: null
+      viewMode: null
+      limit: null
+      selectionLabel: 'Choose a portfolio'
+      localizeRelations: ''
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+  0bab8639-49a8-4bf6-aff7-5ffe60e2bab8:
+    name: Document
+    handle: document
+    instructions: 'Upload the file here'
+    searchable: false
+    translationMethod: site
+    translationKeyFormat: null
+    type: craft\fields\Assets
+    settings:
+      useSingleFolder: '1'
+      defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+      defaultUploadLocationSubpath: ''
+      singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+      singleUploadLocationSubpath: insights/documents
+      restrictFiles: ''
+      allowedKinds:
+        - compressed
+        - excel
+        - html
+        - image
+        - pdf
+        - powerpoint
+        - text
+        - video
+        - word
+      sources: '*'
+      source: null
+      targetSiteId: null
+      viewMode: list
+      limit: '1'
+      selectionLabel: ''
+      localizeRelations: ''
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+  3544eb2e-dd0a-4c86-9474-692a074b6802:
+    name: Tags
+    handle: documentTags
+    instructions: 'Add some keywords to help people find this document (eg. "Volunteering", "Loneliness", "Youth employment" etc)'
+    searchable: true
+    translationMethod: site
+    translationKeyFormat: null
+    type: craft\fields\Tags
+    settings:
+      sources: '*'
+      source: 'taggroup:7e74a4e5-2144-4421-8176-8d66e57f0a3e'
+      targetSiteId: null
+      viewMode: null
+      limit: null
+      selectionLabel: ''
+      localizeRelations: ''
+    contentColumnType: string
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
+  69bcf1c5-c1e1-45db-b20f-76643d1751de:
+    name: 'Partnership Name'
+    handle: partnershipName
+    instructions: 'Add the name of the group or programme this document was produced in partnership with'
+    searchable: true
+    translationMethod: site
+    translationKeyFormat: null
+    type: craft\fields\PlainText
+    settings:
+      placeholder: ''
+      code: ''
+      multiline: ''
+      initialRows: '4'
+      charLimit: ''
+      columnType: text
+    contentColumnType: text
+    fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
 imageTransforms:
   02af4884-899c-46bf-9add-6bfac4b267c8:
     format: null
@@ -3556,7 +3734,25 @@ sections:
         uriFormat: jobs
     type: single
   2b1f6da1-20e9-4176-a181-7ab073fab8f9:
-    enableVersioning: '1'
+    name: 'Funding Programmes'
+    handle: fundingProgrammes
+    type: structure
+    enableVersioning: true
+    propagateEntries: true
+    siteSettings:
+      81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
+        enabledByDefault: true
+        hasUrls: true
+        uriFormat: 'funding/programmes/{slug}'
+        template: funding-programs/_entry
+      d0635f95-a563-4f66-9195-33da0eb644d5:
+        enabledByDefault: true
+        hasUrls: true
+        uriFormat: 'funding/programmes/{slug}'
+        template: funding-programs/_entry
+    structure:
+      uid: 570b86f8-ad2e-487e-b501-2c14f616844a
+      maxLevels: '1'
     entryTypes:
       79c88f21-da56-48db-9e1c-ec15618ca38f:
         name: 'Funding Programmes'
@@ -3637,24 +3833,6 @@ sections:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
-    handle: fundingProgrammes
-    name: 'Funding Programmes'
-    propagateEntries: '1'
-    siteSettings:
-      81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
-        enabledByDefault: '1'
-        hasUrls: '1'
-        template: funding-programs/_entry
-        uriFormat: 'funding/programmes/{slug}'
-      d0635f95-a563-4f66-9195-33da0eb644d5:
-        enabledByDefault: '1'
-        hasUrls: '1'
-        template: funding-programs/_entry
-        uriFormat: 'funding/programmes/{slug}'
-    structure:
-      maxLevels: '1'
-      uid: 570b86f8-ad2e-487e-b501-2c14f616844a
-    type: structure
   2b255d19-d30b-4d89-8555-cddcd1eb945e:
     enableVersioning: '1'
     entryTypes:
@@ -3751,6 +3929,44 @@ sections:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+      e22437bd-941b-4079-9b02-4f37c5b41ea9:
+        name: Document
+        handle: researchDocument
+        hasTitleField: true
+        titleLabel: Title
+        titleFormat: ''
+        sortOrder: 2
+        fieldLayouts:
+          8185a6ba-3549-4be6-92c2-3cd81f83275f:
+            tabs:
+              -
+                name: 'Insight Document'
+                sortOrder: 1
+                fields:
+                  60a339d6-ca4b-48a2-9e48-6c2bbe582b0e:
+                    required: true
+                    sortOrder: 1
+                  5024077b-fccb-4164-8874-8fd05a936e13:
+                    required: true
+                    sortOrder: 2
+                  6ffbb157-9d66-4994-8a8f-947c35960c2d:
+                    required: false
+                    sortOrder: 3
+                  69bcf1c5-c1e1-45db-b20f-76643d1751de:
+                    required: false
+                    sortOrder: 4
+                  ebcd4aaf-83ff-48e4-9f0d-8a7e22313652:
+                    required: true
+                    sortOrder: 5
+                  0bab8639-49a8-4bf6-aff7-5ffe60e2bab8:
+                    required: true
+                    sortOrder: 6
+                  f91f1b44-ef7d-4f91-8d75-75ad6ae3a677:
+                    required: false
+                    sortOrder: 7
+                  3544eb2e-dd0a-4c86-9474-692a074b6802:
+                    required: true
+                    sortOrder: 8
     handle: research
     name: Insights
     propagateEntries: '1'

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -24,105 +24,65 @@ class ResearchTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $common = ContentHelpers::getCommonFields($entry, $status, $this->locale);
+        $researchMeta = $entry->researchMeta->one();
+        return array_merge(ContentHelpers::getCommonFields($entry, $status, $this->locale), [
+            // @TODO: Remove thumbnail in favour of trailImage once all pages have new hero images
+            'thumbnail' => self::buildTrailImage(Images::extractImage($entry->heroImage)),
+            'trailImage' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
 
-        if ($entry->type->handle === 'research') {
-            $researchMeta = $entry->researchMeta->one();
-            return array_merge($common, [
-                // @TODO: Remove thumbnail in favour of trailImage once all pages have new hero images
-                'thumbnail' => self::buildTrailImage(Images::extractImage($entry->heroImage)),
-                'trailImage' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
+            'introduction' => $entry->introductionText ?? null,
+            'contactEmail' => $researchMeta ? $researchMeta->contactEmail : null,
+            'researchPartners' => $researchMeta ? $researchMeta->researchPartners : null,
 
-                'introduction' => $entry->introductionText ?? null,
-                'contactEmail' => $researchMeta ? $researchMeta->contactEmail : null,
-                'researchPartners' => $researchMeta ? $researchMeta->researchPartners : null,
-
-                'documentsPrefix' => $entry->researchDocumentsPrefix ?? null,
-                'documents' => array_map(function ($document) {
-                    $asset = $document->documentAsset->one();
-                    return [
-                        'title' => $document->documentTitle,
-                        'url' => $asset->url,
-                        'filetype' => $asset->extension,
-                        'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0),
-                        'contents' => $document->documentContents ? explode("\n", $document->documentContents) : [],
-                    ];
-                }, $entry->researchDocuments->all() ?? []),
-
-                'relatedFundingProgrammes' => array_map(function ($programme) {
-                    return [
-                        'title' => $programme->title,
-                        'linkUrl' => $programme->externalUrl ? $programme->externalUrl : EntryHelpers::uriForLocale($programme->uri, $this->locale),
-                    ];
-                }, $entry->relatedFundingProgrammes->all() ?? []),
-
-                'sectionsPrefix' => $entry->researchSectionsPrefix ?? null,
-                'sections' => array_map(function ($row) {
-                    return [
-                        'title' => $row->sectionTitle,
-                        'prefix' => $row->sectionPrefix ?? null,
-                        'parts' => array_map(function ($block) {
-                            switch ($block->type->handle) {
-                                case 'contentArea':
-                                    return [
-                                        'type' => $block->type->handle,
-                                        'title' => $block->contentTitle,
-                                        'content' => $block->contentBody,
-                                    ];
-                                    break;
-                                case 'callout':
-                                    return [
-                                        'type' => $block->type->handle,
-                                        'content' => $block->calloutContent,
-                                        'credit' => $block->calloutCredit ?? null,
-                                        'isQuote' => $block->isQuote,
-                                    ];
-                                    break;
-                            }
-                        }, $row->contentSections->all() ?? [])
-                    ];
-                }, $entry->researchSections->all() ?? []),
-
-                'meta' => [
-                    'searchScore' => $entry->searchScore ?? null,
-                ],
-            ]);
-        } else {
-
-            $asset = !empty($entry->document) ? $entry->document->one() : null;
-            $documentData = $asset ? [
-                'url' => $asset->url,
-                'filetype' => $asset->extension,
-                'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0)
-            ] : null;
-
-            $relatedInsightsPage = null;
-            if (!empty($entry->relatedInsightsPage->one())) {
-                $page = $entry->relatedInsightsPage->one();
-                $relatedInsightsPage = [
-                    'title' => $page->title,
-                    'linkUrl' => $page->externalUrl ? $page->externalUrl : EntryHelpers::uriForLocale($page->uri, $this->locale),
+            'documentsPrefix' => $entry->researchDocumentsPrefix ?? null,
+            'documents' => array_map(function ($document) {
+                $asset = $document->documentAsset->one();
+                return [
+                    'title' => $document->documentTitle,
+                    'url' => $asset->url,
+                    'filetype' => $asset->extension,
+                    'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0),
+                    'contents' => $document->documentContents ? explode("\n", $document->documentContents) : [],
                 ];
-            }
+            }, $entry->researchDocuments->all() ?? []),
 
+            'relatedFundingProgrammes' => array_map(function ($programme) {
+                return [
+                    'title' => $programme->title,
+                    'linkUrl' => $programme->externalUrl ? $programme->externalUrl : EntryHelpers::uriForLocale($programme->uri, $this->locale),
+                ];
+            }, $entry->relatedFundingProgrammes->all() ?? []),
 
-            return array_merge($common, [
-                'summary' => $entry->summary,
-                'relatedFundingProgrammes' => array_map(function ($programme) {
-                    return [
-                        'title' => $programme->title,
-                        'linkUrl' => $programme->externalUrl ? $programme->externalUrl : EntryHelpers::uriForLocale($programme->uri, $this->locale),
-                    ];
-                }, $entry->programme->all() ?? []),
-                'portfolio' => !empty($entry->portfolio) ? ContentHelpers::nestedCategorySummary($entry->portfolio->all(), $this->locale) : [],
-                'partnershipName' => $entry->partnershipName,
-                'documentType' => !empty($entry->documentType->all()) ? ContentHelpers::categorySummary($entry->documentType->one(), $this->locale) : [],
-                'document' => $documentData,
-                'publisher' => $entry->publisher,
-                'tags' => !empty($entry->documentTags) ? ContentHelpers::getTags($entry->documentTags->all(), $this->locale) : null,
-                'relatedInsightsPage' => $relatedInsightsPage
-            ]);
-        }
+            'sectionsPrefix' => $entry->researchSectionsPrefix ?? null,
+            'sections' => array_map(function ($row) {
+                return [
+                    'title' => $row->sectionTitle,
+                    'prefix' => $row->sectionPrefix ?? null,
+                    'parts' => array_map(function ($block) {
+                        switch ($block->type->handle) {
+                            case 'contentArea':
+                                return [
+                                    'type' => $block->type->handle,
+                                    'title' => $block->contentTitle,
+                                    'content' => $block->contentBody,
+                                ];
+                                break;
+                            case 'callout':
+                                return [
+                                    'type' => $block->type->handle,
+                                    'content' => $block->calloutContent,
+                                    'credit' => $block->calloutCredit ?? null,
+                                    'isQuote' => $block->isQuote,
+                                ];
+                                break;
+                        }
+                    }, $row->contentSections->all() ?? [])
+                ];
+            }, $entry->researchSections->all() ?? []),
 
+            'meta' => [
+                'searchScore' => $entry->searchScore ?? null,
+            ],
+        ]);
     }
 }

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -89,12 +89,12 @@ class ResearchTransformer extends TransformerAbstract
             ]);
         } else {
 
-            $asset = $entry->document->one();
-            $documentData = [
+            $asset = !empty($entry->document) ? $entry->document->one() : null;
+            $documentData = $asset ? [
                 'url' => $asset->url,
                 'filetype' => $asset->kind,
                 'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0)
-            ];
+            ] : null;
 
             return array_merge($common, [
                 'summary' => $entry->summary,
@@ -106,7 +106,7 @@ class ResearchTransformer extends TransformerAbstract
                 }, $entry->programme->all() ?? []),
                 'portfolio' => !empty($entry->portfolio) ? ContentHelpers::nestedCategorySummary($entry->portfolio->all(), $this->locale) : [],
                 'partnershipName' => $entry->partnershipName,
-                'documentType' => !empty($entry->documentType) ? ContentHelpers::categorySummary($entry->documentType->one(), $this->locale) : [],
+                'documentType' => !empty($entry->documentType->all()) ? ContentHelpers::categorySummary($entry->documentType->one(), $this->locale) : [],
                 'document' => $documentData,
                 'publisher' => $entry->publisher,
                 'tags' => !empty($entry->documentTags) ? ContentHelpers::getTags($entry->documentTags->all(), $this->locale) : null,

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -43,7 +43,7 @@ class ResearchTransformer extends TransformerAbstract
                     return [
                         'title' => $document->documentTitle,
                         'url' => $asset->url,
-                        'filetype' => $asset->kind,
+                        'filetype' => $asset->extension,
                         'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0),
                         'contents' => $document->documentContents ? explode("\n", $document->documentContents) : [],
                     ];
@@ -92,9 +92,19 @@ class ResearchTransformer extends TransformerAbstract
             $asset = !empty($entry->document) ? $entry->document->one() : null;
             $documentData = $asset ? [
                 'url' => $asset->url,
-                'filetype' => $asset->kind,
+                'filetype' => $asset->extension,
                 'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0)
             ] : null;
+
+            $relatedInsightsPage = null;
+            if (!empty($entry->relatedInsightsPage->one())) {
+                $page = $entry->relatedInsightsPage->one();
+                $relatedInsightsPage = [
+                    'title' => $page->title,
+                    'linkUrl' => $page->externalUrl ? $page->externalUrl : EntryHelpers::uriForLocale($page->uri, $this->locale),
+                ];
+            }
+
 
             return array_merge($common, [
                 'summary' => $entry->summary,
@@ -110,6 +120,7 @@ class ResearchTransformer extends TransformerAbstract
                 'document' => $documentData,
                 'publisher' => $entry->publisher,
                 'tags' => !empty($entry->documentTags) ? ContentHelpers::getTags($entry->documentTags->all(), $this->locale) : null,
+                'relatedInsightsPage' => $relatedInsightsPage
             ]);
         }
 

--- a/lib/ResearchDocument.php
+++ b/lib/ResearchDocument.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace biglotteryfund\utils;
+
+use biglotteryfund\utils\ContentHelpers;
+use craft\elements\Entry;
+use League\Fractal\TransformerAbstract;
+
+class ResearchDocumentTransformer extends TransformerAbstract
+{
+    public function __construct($locale)
+    {
+        $this->locale = $locale;
+    }
+
+    public function transform(Entry $entry)
+    {
+        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
+
+        $asset = !empty($entry->document) ? $entry->document->one() : null;
+        $documentData = $asset ? [
+            'url' => $asset->url,
+            'filetype' => $asset->extension,
+            'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0)
+        ] : null;
+
+        $relatedInsightsPage = null;
+        if (!empty($entry->relatedInsightsPage->one())) {
+            $page = $entry->relatedInsightsPage->one();
+            $relatedInsightsPage = [
+                'title' => $page->title,
+                'linkUrl' => $page->externalUrl ? $page->externalUrl : EntryHelpers::uriForLocale($page->uri, $this->locale),
+            ];
+        }
+
+        return array_merge(ContentHelpers::getCommonFields($entry, $status, $this->locale), [
+            'summary' => $entry->summary,
+            'relatedFundingProgrammes' => array_map(function ($programme) {
+                return [
+                    'title' => $programme->title,
+                    'linkUrl' => $programme->externalUrl ? $programme->externalUrl : EntryHelpers::uriForLocale($programme->uri, $this->locale),
+                ];
+            }, $entry->programme->all() ?? []),
+            'portfolio' => !empty($entry->portfolio) ? ContentHelpers::nestedCategorySummary($entry->portfolio->all(), $this->locale) : [],
+            'partnershipName' => $entry->partnershipName,
+            'documentType' => !empty($entry->documentType->all()) ? ContentHelpers::categorySummary($entry->documentType->one(), $this->locale) : [],
+            'document' => $documentData,
+            'publisher' => $entry->publisher,
+            'tags' => !empty($entry->documentTags) ? ContentHelpers::getTags($entry->documentTags->all(), $this->locale) : null,
+            'relatedInsightsPage' => $relatedInsightsPage
+        ]);
+    }
+}


### PR DESCRIPTION
This adds a new section for Insights Documents:

![image](https://user-images.githubusercontent.com/394376/55073824-a7a5a000-5086-11e9-80da-0c884ef1913f.png)

It allows us to upload a bunch of older research documents and then filter them on the frontend, a little like the Press Releases section.

