### PR TITLE
Improve performance of funding programmes endpoint

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -169,18 +169,22 @@ function getFundingProgrammes($locale, $slug = null)
     } else if (\Craft::$app->request->getParam('all') === 'true') {
         $criteria['orderBy'] = 'title asc';
         $criteria['status'] = ['live', 'expired'];
+    } else if (\Craft::$app->request->getParam('newest') === 'true') {
+        $criteria['orderBy'] = 'postDate desc';
     } else {
         // For listing pages, only show programmes that can be directly applied to
         $criteria['programmeStatus'] = 'open';
     }
 
+    $isSingle = !!$slug;
+
     return [
         'serializer' => 'jsonApi',
         'elementType' => Entry::class,
         'criteria' => $criteria,
-        'one' => $slug ? true : false,
+        'one' => $isSingle,
         'elementsPerPage' => \Craft::$app->request->getParam('page-limit') ?: 100,
-        'transformer' => new FundingProgrammeTransformer($locale),
+        'transformer' => new FundingProgrammeTransformer($locale, $isSingle),
     ];
 }
 

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -58,6 +58,8 @@ fieldGroups:
     name: Research
   9a6de417-cda1-486f-9022-b8c5387f751e:
     name: 'Funding Programmes'
+  a9adb8e8-0825-43f9-8f1a-862323940637:
+    name: 'Social Media'
   e3237b61-2fe0-45f7-9036-c1ff7a7975e8:
     name: Data
   f0f968ce-8ae3-4607-9e2f-c7d06f196869:
@@ -66,8 +68,6 @@ fieldGroups:
     name: Homepage
   fe37f91c-b0e2-482c-8482-05d9b335ce86:
     name: Merchandise
-  a9adb8e8-0825-43f9-8f1a-862323940637:
-    name: 'Social Media'
 fields:
   02eb210a-8b09-489c-994d-009c27b6167b:
     contentColumnType: string
@@ -621,6 +621,21 @@ fields:
     translationKeyFormat: null
     translationMethod: site
     type: craft\redactor\Field
+  6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
+    contentColumnType: string
+    fieldGroup: a9adb8e8-0825-43f9-8f1a-862323940637
+    handle: socialMediaTags
+    instructions: 'Add some Open Graph metadata which displays when this content is shared on social media (eg. Twitter and Facebook cards)'
+    name: 'Social Media Tags'
+    searchable: false
+    settings:
+      contentTable: '{{%matrixcontent_socialmediatags}}'
+      localizeBlocks: '1'
+      maxBlocks: ''
+      minBlocks: ''
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\Matrix
   6c792519-1c25-4194-a0e5-60377539e790:
     contentColumnType: string
     fieldGroup: 1770279d-fae8-42d7-9209-2e4e311f9e8a
@@ -1585,21 +1600,6 @@ fields:
     translationKeyFormat: null
     translationMethod: none
     type: craft\fields\PlainText
-  6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
-    name: 'Social Media Tags'
-    handle: socialMediaTags
-    instructions: 'Add some Open Graph metadata which displays when this content is shared on social media (eg. Twitter and Facebook cards)'
-    searchable: false
-    translationMethod: site
-    translationKeyFormat: null
-    type: craft\fields\Matrix
-    settings:
-      minBlocks: ''
-      maxBlocks: ''
-      contentTable: '{{%matrixcontent_socialmediatags}}'
-      localizeBlocks: '1'
-    contentColumnType: string
-    fieldGroup: a9adb8e8-0825-43f9-8f1a-862323940637
 imageTransforms:
   02af4884-899c-46bf-9add-6bfac4b267c8:
     format: null
@@ -2755,6 +2755,137 @@ matrixBlockTypes:
     handle: contentArea
     name: 'Content Area'
     sortOrder: '1'
+  cdf38474-7e76-4140-aecb-1e2962f2a9b7:
+    field: 6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51
+    fieldLayouts:
+      df689c5d-a020-4ec2-971f-ca2cd8f5c1b1:
+        tabs:
+          -
+            fields:
+              10b1092c-6186-4d57-825b-29af4519292d:
+                required: false
+                sortOrder: 2
+              313a413e-2758-4963-8abf-7ae418034c90:
+                required: false
+                sortOrder: 3
+              34c79cfe-a250-4f37-9db7-09538f105c74:
+                required: false
+                sortOrder: 1
+              c147383b-5f6d-449c-9120-0ac3da15a85f:
+                required: false
+                sortOrder: 5
+              d0c63510-508c-48bf-8cf2-20b02e9682f7:
+                required: false
+                sortOrder: 4
+            name: Content
+            sortOrder: 1
+    fields:
+      10b1092c-6186-4d57-825b-29af4519292d:
+        contentColumnType: text
+        fieldGroup: null
+        handle: ogDescription
+        instructions: 'A brief description of the content, usually between 2 and 4 sentences. This will displayed below the title of the post on Facebook.'
+        name: Description
+        searchable: true
+        settings:
+          charLimit: ''
+          code: ''
+          columnType: text
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      313a413e-2758-4963-8abf-7ae418034c90:
+        contentColumnType: string
+        fieldGroup: null
+        handle: ogFacebookImage
+        instructions: "• Open Graph Stories – Images appear in a square format. Image ratios for these apps should be 600 x 600 px.\r\n• Non-open Graph Stories – Images appear in a rectangular format. You should use a 1.91:1 image ratio, such as 600 x 314 px."
+        name: 'Facebook Image'
+        searchable: true
+        settings:
+          allowedKinds:
+            - image
+          defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          defaultUploadLocationSubpath: ''
+          limit: '1'
+          localizeRelations: ''
+          restrictFiles: '1'
+          selectionLabel: ''
+          singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          singleUploadLocationSubpath: social/facebook
+          source: null
+          sources: '*'
+          targetSiteId: null
+          useSingleFolder: '1'
+          viewMode: list
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\Assets
+      34c79cfe-a250-4f37-9db7-09538f105c74:
+        contentColumnType: text
+        fieldGroup: null
+        handle: ogTitle
+        instructions: "The title of this article without any branding (such as our site name). If left blank, the current entry title will be used.\r\n"
+        name: Title
+        searchable: true
+        settings:
+          charLimit: ''
+          code: ''
+          columnType: text
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      c147383b-5f6d-449c-9120-0ac3da15a85f:
+        contentColumnType: text
+        fieldGroup: null
+        handle: ogSlug
+        instructions: 'Optional – if you specify this then only a unique URL (eg. ?social=<slug>) will show these social media assets.'
+        name: Slug
+        searchable: true
+        settings:
+          charLimit: ''
+          code: ''
+          columnType: text
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      d0c63510-508c-48bf-8cf2-20b02e9682f7:
+        contentColumnType: string
+        fieldGroup: null
+        handle: ogTwitterImage
+        instructions: "• Images for Twitter Cards support an aspect ratio of 2:1 with minimum dimensions of 300x157 or maximum of 4096x4096 pixels.\r\n• Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported."
+        name: 'Twitter Image'
+        searchable: true
+        settings:
+          allowedKinds:
+            - image
+          defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          defaultUploadLocationSubpath: ''
+          limit: '1'
+          localizeRelations: ''
+          restrictFiles: '1'
+          selectionLabel: ''
+          singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          singleUploadLocationSubpath: social/twitter
+          source: null
+          sources: '*'
+          targetSiteId: null
+          useSingleFolder: '1'
+          viewMode: list
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\Assets
+    handle: openGraphTags
+    name: 'Open Graph Tags'
+    sortOrder: 1
   d0984ff1-7885-4dff-b648-3af3e222ade9:
     field: 093b4dc3-16d8-439a-a963-39b9c9d7c164
     fieldLayouts:
@@ -3240,137 +3371,6 @@ matrixBlockTypes:
     handle: product
     name: Product
     sortOrder: '1'
-  cdf38474-7e76-4140-aecb-1e2962f2a9b7:
-    field: 6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51
-    name: 'Open Graph Tags'
-    handle: openGraphTags
-    sortOrder: 1
-    fields:
-      34c79cfe-a250-4f37-9db7-09538f105c74:
-        name: Title
-        handle: ogTitle
-        instructions: "The title of this article without any branding (such as our site name). If left blank, the current entry title will be used.\r\n"
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\PlainText
-        settings:
-          placeholder: ''
-          code: ''
-          multiline: ''
-          initialRows: '4'
-          charLimit: ''
-          columnType: text
-        contentColumnType: text
-        fieldGroup: null
-      10b1092c-6186-4d57-825b-29af4519292d:
-        name: Description
-        handle: ogDescription
-        instructions: 'A brief description of the content, usually between 2 and 4 sentences. This will displayed below the title of the post on Facebook.'
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\PlainText
-        settings:
-          placeholder: ''
-          code: ''
-          multiline: ''
-          initialRows: '4'
-          charLimit: ''
-          columnType: text
-        contentColumnType: text
-        fieldGroup: null
-      313a413e-2758-4963-8abf-7ae418034c90:
-        name: 'Facebook Image'
-        handle: ogFacebookImage
-        instructions: "• Open Graph Stories – Images appear in a square format. Image ratios for these apps should be 600 x 600 px.\r\n• Non-open Graph Stories – Images appear in a rectangular format. You should use a 1.91:1 image ratio, such as 600 x 314 px."
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\Assets
-        settings:
-          useSingleFolder: '1'
-          defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-          defaultUploadLocationSubpath: ''
-          singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-          singleUploadLocationSubpath: social/facebook
-          restrictFiles: '1'
-          allowedKinds:
-            - image
-          sources: '*'
-          source: null
-          targetSiteId: null
-          viewMode: list
-          limit: '1'
-          selectionLabel: ''
-          localizeRelations: ''
-        contentColumnType: string
-        fieldGroup: null
-      d0c63510-508c-48bf-8cf2-20b02e9682f7:
-        name: 'Twitter Image'
-        handle: ogTwitterImage
-        instructions: "• Images for Twitter Cards support an aspect ratio of 2:1 with minimum dimensions of 300x157 or maximum of 4096x4096 pixels.\r\n• Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported."
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\Assets
-        settings:
-          useSingleFolder: '1'
-          defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-          defaultUploadLocationSubpath: ''
-          singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
-          singleUploadLocationSubpath: social/twitter
-          restrictFiles: '1'
-          allowedKinds:
-            - image
-          sources: '*'
-          source: null
-          targetSiteId: null
-          viewMode: list
-          limit: '1'
-          selectionLabel: ''
-          localizeRelations: ''
-        contentColumnType: string
-        fieldGroup: null
-      c147383b-5f6d-449c-9120-0ac3da15a85f:
-        name: Slug
-        handle: ogSlug
-        instructions: 'Optional – if you specify this then only a unique URL (eg. ?social=<slug>) will show these social media assets.'
-        searchable: true
-        translationMethod: site
-        translationKeyFormat: null
-        type: craft\fields\PlainText
-        settings:
-          placeholder: ''
-          code: ''
-          multiline: ''
-          initialRows: '4'
-          charLimit: ''
-          columnType: text
-        contentColumnType: text
-        fieldGroup: null
-    fieldLayouts:
-      df689c5d-a020-4ec2-971f-ca2cd8f5c1b1:
-        tabs:
-          -
-            name: Content
-            sortOrder: 1
-            fields:
-              34c79cfe-a250-4f37-9db7-09538f105c74:
-                required: false
-                sortOrder: 1
-              10b1092c-6186-4d57-825b-29af4519292d:
-                required: false
-                sortOrder: 2
-              313a413e-2758-4963-8abf-7ae418034c90:
-                required: false
-                sortOrder: 3
-              d0c63510-508c-48bf-8cf2-20b02e9682f7:
-                required: false
-                sortOrder: 4
-              c147383b-5f6d-449c-9120-0ac3da15a85f:
-                required: false
-                sortOrder: 5
 plugins:
   aws-s3:
     enabled: '1'
@@ -3456,38 +3456,38 @@ sections:
     enableVersioning: '1'
     entryTypes:
       6cefbe41-9224-4ce3-94bd-740423659c18:
-        name: 'Building Better Opportunities'
-        handle: buildingBetterOpportunities
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           3dbd0510-0cfc-4a98-8dd2-1d78a606c7f6:
             tabs:
               -
-                name: 'Content Page'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
+                  0ffe78fe-8cab-4c76-a558-5dcb3cb2dd34:
                     required: false
-                    sortOrder: 1
+                    sortOrder: 4
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: true
                     sortOrder: 3
-                  0ffe78fe-8cab-4c76-a558-5dcb3cb2dd34:
+                  99eaaae9-87e0-4b54-a247-504431915423:
                     required: false
-                    sortOrder: 4
+                    sortOrder: 1
+                name: 'Content Page'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: buildingBetterOpportunities
+        hasTitleField: true
+        name: 'Building Better Opportunities'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: buildingBetterOpportunities
     name: 'Building Better Opportunities'
     propagateEntries: '1'
@@ -3505,41 +3505,41 @@ sections:
     enableVersioning: '1'
     entryTypes:
       9147c461-7eef-4d50-af6e-474010b5a504:
-        name: Jobs
-        handle: jobs
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           465ad913-dff2-4ca8-bfb1-408cfcaf83e9:
             tabs:
               -
-                name: 'Jobs page content'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 3
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 4
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 5
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: 'Jobs page content'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: jobs
+        hasTitleField: true
+        name: Jobs
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: jobs
     name: Jobs
     propagateEntries: '1'
@@ -3559,84 +3559,84 @@ sections:
     enableVersioning: '1'
     entryTypes:
       79c88f21-da56-48db-9e1c-ec15618ca38f:
-        name: 'Funding Programmes'
-        handle: fundingProgrammes
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           96266c61-497d-41b4-9e92-9b62178dbf1b:
             tabs:
               -
-                name: 'Programme Details'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
-                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
-                    required: false
-                    sortOrder: 2
-                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
-                    required: false
-                    sortOrder: 3
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
-                    required: false
-                    sortOrder: 4
-                  bcbf9339-ab42-4e3f-9db7-eaf3b499d36c:
-                    required: false
-                    sortOrder: 5
                   03ed24af-07b1-42c3-875e-98050e9560c7:
                     required: false
                     sortOrder: 6
+                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
+                    required: false
+                    sortOrder: 3
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 7
-              -
-                name: 'Programme Summary'
-                sortOrder: 2
-                fields:
-                  5899dcd7-1384-49e0-98a5-633b44fa05c0:
+                  99eaaae9-87e0-4b54-a247-504431915423:
                     required: false
                     sortOrder: 1
-                  b1cb76e6-64d2-41f8-837d-089907b480c6:
+                  bcbf9339-ab42-4e3f-9db7-eaf3b499d36c:
+                    required: false
+                    sortOrder: 5
+                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
                     required: false
                     sortOrder: 2
-                  650ff388-625b-4f42-82bd-10a96d6b47b1:
-                    required: false
-                    sortOrder: 3
-                  ee5ad666-8266-45cc-9852-f681a7db300f:
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
                     required: false
                     sortOrder: 4
+                name: 'Programme Details'
+                sortOrder: 1
+              -
+                fields:
                   0db131ea-69e3-4c13-955d-b607df3c9959:
                     required: false
                     sortOrder: 5
-                  8d3adb13-80ec-4b1a-9524-7b23bafb6c60:
-                    required: false
-                    sortOrder: 6
-                  c2f8265a-898e-4f67-abf9-45dabc783f7e:
-                    required: false
-                    sortOrder: 7
-                  9af6d5eb-9e64-473d-b1c3-5642ec2ead05:
-                    required: false
-                    sortOrder: 8
                   1338f3a8-bad4-4e23-a0f0-327be8f16e60:
                     required: false
                     sortOrder: 9
                   46d0352f-42af-4d63-be4d-9c9df54c5871:
                     required: false
                     sortOrder: 10
+                  5899dcd7-1384-49e0-98a5-633b44fa05c0:
+                    required: false
+                    sortOrder: 1
+                  650ff388-625b-4f42-82bd-10a96d6b47b1:
+                    required: false
+                    sortOrder: 3
+                  8d3adb13-80ec-4b1a-9524-7b23bafb6c60:
+                    required: false
+                    sortOrder: 6
+                  9af6d5eb-9e64-473d-b1c3-5642ec2ead05:
+                    required: false
+                    sortOrder: 8
+                  b1cb76e6-64d2-41f8-837d-089907b480c6:
+                    required: false
+                    sortOrder: 2
+                  c2f8265a-898e-4f67-abf9-45dabc783f7e:
+                    required: false
+                    sortOrder: 7
                   e5147d7e-c0d3-4cb2-92cf-3b5e5eae96e6:
                     required: false
                     sortOrder: 11
+                  ee5ad666-8266-45cc-9852-f681a7db300f:
+                    required: false
+                    sortOrder: 4
+                name: 'Programme Summary'
+                sortOrder: 2
               -
-                name: 'Social Media'
-                sortOrder: 3
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 3
+        handle: fundingProgrammes
+        hasTitleField: true
+        name: 'Funding Programmes'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: fundingProgrammes
     name: 'Funding Programmes'
     propagateEntries: '1'
@@ -3697,60 +3697,60 @@ sections:
     enableVersioning: '1'
     entryTypes:
       803ebe88-78a2-4e00-8b3c-a8649ffb61ce:
-        name: Research
-        handle: research
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           148090b7-1887-40f5-a00e-8d90a513eb77:
             tabs:
               -
-                name: 'Main content'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: true
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 4
                   4b573749-5271-405a-9d27-9e086ee1f31f:
                     required: false
                     sortOrder: 5
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 4
                   83a59f94-8342-417f-b427-11c3c162d89e:
                     required: true
                     sortOrder: 6
-              -
-                name: 'Related content'
-                sortOrder: 2
-                fields:
-                  d152a0b3-b09f-4b2c-a7a6-605b9a0fed17:
-                    required: false
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
                     sortOrder: 1
-                  f946d578-25d4-40b3-a68b-f04068f34a17:
-                    required: false
-                    sortOrder: 2
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: true
+                    sortOrder: 3
+                name: 'Main content'
+                sortOrder: 1
+              -
+                fields:
                   585a68f7-bb7c-4d7f-9acf-10f9b2107243:
                     required: true
                     sortOrder: 3
                   7a4edc2b-a06d-4baf-a33f-da76742cbf35:
                     required: false
                     sortOrder: 4
+                  d152a0b3-b09f-4b2c-a7a6-605b9a0fed17:
+                    required: false
+                    sortOrder: 1
+                  f946d578-25d4-40b3-a68b-f04068f34a17:
+                    required: false
+                    sortOrder: 2
+                name: 'Related content'
+                sortOrder: 2
               -
-                name: 'Social Media'
-                sortOrder: 3
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 3
+        handle: research
+        hasTitleField: true
+        name: Research
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: research
     name: Insights
     propagateEntries: '1'
@@ -3770,32 +3770,32 @@ sections:
     enableVersioning: '1'
     entryTypes:
       a11f990c-b6b9-4887-bfc3-5aaca8b7c3c0:
-        name: Aliases
-        handle: aliases
-        hasTitleField: false
-        titleLabel: ''
-        titleFormat: '{slug}'
-        sortOrder: 1
         fieldLayouts:
           fda6063b-17f6-4bd4-b0eb-42fdcf0031ef:
             tabs:
               -
-                name: Aliases
-                sortOrder: 1
                 fields:
-                  adfb9aa8-ae2e-4b0e-9068-1a58c62105b0:
-                    required: false
-                    sortOrder: 1
                   02eb210a-8b09-489c-994d-009c27b6167b:
                     required: false
                     sortOrder: 2
+                  adfb9aa8-ae2e-4b0e-9068-1a58c62105b0:
+                    required: false
+                    sortOrder: 1
+                name: Aliases
+                sortOrder: 1
               -
-                name: 'Delete Me'
-                sortOrder: 2
                 fields:
                   e5ca4911-ec90-44e6-8349-34361a8da221:
                     required: false
                     sortOrder: 1
+                name: 'Delete Me'
+                sortOrder: 2
+        handle: aliases
+        hasTitleField: false
+        name: Aliases
+        sortOrder: 1
+        titleFormat: '{slug}'
+        titleLabel: ''
     handle: aliases
     name: Aliases
     propagateEntries: '0'
@@ -3815,158 +3815,158 @@ sections:
     enableVersioning: '1'
     entryTypes:
       16b4a64e-3a41-41d6-9cb0-abbb0b37773f:
-        name: 'News article'
-        handle: updates
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 2
         fieldLayouts:
           6ccb5707-3d48-45e4-83a9-8baed98aac34:
             tabs:
               -
-                name: 'Article content'
-                sortOrder: 1
                 fields:
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: false
-                    sortOrder: 1
                   1b339885-ec9d-4871-852a-6ab021977805:
                     required: false
                     sortOrder: 2
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
-                    required: false
-                    sortOrder: 3
-                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
-                    required: false
-                    sortOrder: 4
-                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
-                    required: false
-                    sortOrder: 5
+                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
+                    required: true
+                    sortOrder: 8
                   419ecf2d-b6f9-4754-a309-88579895b504:
                     required: false
                     sortOrder: 6
                   7a4edc2b-a06d-4baf-a33f-da76742cbf35:
                     required: false
                     sortOrder: 7
-                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
-                    required: true
-                    sortOrder: 8
+                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
+                    required: false
+                    sortOrder: 5
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: false
+                    sortOrder: 1
+                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
+                    required: false
+                    sortOrder: 4
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                    required: false
+                    sortOrder: 3
+                name: 'Article content'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
-      af57c0a7-4c55-470e-9331-03fc4c25b6f9:
-        name: Blogpost
-        handle: blog
+                name: 'Social Media'
+                sortOrder: 2
+        handle: updates
         hasTitleField: true
-        titleLabel: Title
+        name: 'News article'
+        sortOrder: 2
         titleFormat: ''
-        sortOrder: 3
+        titleLabel: Title
+      af57c0a7-4c55-470e-9331-03fc4c25b6f9:
         fieldLayouts:
           cd1b7bf5-abb9-4d14-aa3c-a4cbfdfe88fe:
             tabs:
               -
-                name: 'Blog post'
-                sortOrder: 1
                 fields:
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: false
-                    sortOrder: 1
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
-                    required: false
-                    sortOrder: 2
-                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
-                    required: false
-                    sortOrder: 3
+                  0cfefd57-0c56-49da-921e-dd45bf0146a8:
+                    required: true
+                    sortOrder: 6
                   1b339885-ec9d-4871-852a-6ab021977805:
                     required: false
                     sortOrder: 4
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: true
                     sortOrder: 5
-                  0cfefd57-0c56-49da-921e-dd45bf0146a8:
-                    required: true
-                    sortOrder: 6
                   419ecf2d-b6f9-4754-a309-88579895b504:
                     required: false
                     sortOrder: 7
-                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
-                    required: false
-                    sortOrder: 8
                   7a4edc2b-a06d-4baf-a33f-da76742cbf35:
                     required: false
                     sortOrder: 9
+                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
+                    required: false
+                    sortOrder: 3
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: false
+                    sortOrder: 1
+                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
+                    required: false
+                    sortOrder: 8
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                    required: false
+                    sortOrder: 2
+                name: 'Blog post'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
-      c9f7e8cb-c731-4f5f-8f52-41611666b3a5:
-        name: 'Press Release'
-        handle: press_releases
+                name: 'Social Media'
+                sortOrder: 2
+        handle: blog
         hasTitleField: true
-        titleLabel: Title
+        name: Blogpost
+        sortOrder: 3
         titleFormat: ''
-        sortOrder: 1
+        titleLabel: Title
+      c9f7e8cb-c731-4f5f-8f52-41611666b3a5:
         fieldLayouts:
           331affbf-f1ba-4a26-a8cb-7d21de2435c5:
             tabs:
               -
-                name: 'Press Release'
-                sortOrder: 1
                 fields:
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                  18a9853a-8570-41b5-9be5-89b09f045a67:
                     required: false
-                    sortOrder: 1
+                    sortOrder: 10
                   1b339885-ec9d-4871-852a-6ab021977805:
                     required: false
                     sortOrder: 2
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                  25308ee1-088a-4b07-83df-c7100eab536e:
                     required: false
-                    sortOrder: 3
-                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
+                    sortOrder: 12
+                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: false
-                    sortOrder: 4
-                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
-                    required: false
-                    sortOrder: 5
+                    sortOrder: 9
                   419ecf2d-b6f9-4754-a309-88579895b504:
                     required: false
                     sortOrder: 6
                   7a4edc2b-a06d-4baf-a33f-da76742cbf35:
                     required: false
                     sortOrder: 7
-                  ea2c21db-5b6a-43db-adf0-299005c96e09:
-                    required: true
-                    sortOrder: 8
-                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
+                  b7e76d5c-aec3-4fbd-8917-ac0907db656e:
                     required: false
-                    sortOrder: 9
-                  18a9853a-8570-41b5-9be5-89b09f045a67:
+                    sortOrder: 5
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
                     required: false
-                    sortOrder: 10
-                  fb58a355-aa74-4216-b874-3c723f101d50:
-                    required: false
-                    sortOrder: 11
-                  25308ee1-088a-4b07-83df-c7100eab536e:
-                    required: false
-                    sortOrder: 12
+                    sortOrder: 1
                   de9ed6f6-ee49-45c7-a685-cf952a498f91:
                     required: false
                     sortOrder: 13
+                  e1e77fc0-240c-43d7-828f-fe39e28553b9:
+                    required: false
+                    sortOrder: 4
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                    required: false
+                    sortOrder: 3
+                  ea2c21db-5b6a-43db-adf0-299005c96e09:
+                    required: true
+                    sortOrder: 8
+                  fb58a355-aa74-4216-b874-3c723f101d50:
+                    required: false
+                    sortOrder: 11
+                name: 'Press Release'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: press_releases
+        hasTitleField: true
+        name: 'Press Release'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: updates
     name: Updates
     propagateEntries: '1'
@@ -3986,38 +3986,38 @@ sections:
     enableVersioning: '1'
     entryTypes:
       32545da5-c0fa-45f7-90c9-5ebc1eb2079c:
-        name: Merchandise
-        handle: merchandise
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           caed816f-70b3-4340-b299-61181fa28f49:
             tabs:
               -
-                name: Merchandise
-                sortOrder: 1
                 fields:
-                  db0b8702-ef1b-409c-aa55-6de9d41d4d4a:
-                    required: false
-                    sortOrder: 1
-                  ce51477f-1fbc-4c51-a482-621384b56698:
-                    required: true
-                    sortOrder: 2
-                  e2c780b8-c133-4e69-af2f-cee1076275cd:
-                    required: true
-                    sortOrder: 3
                   85937a58-39af-479b-b64b-283999b877df:
                     required: false
                     sortOrder: 4
+                  ce51477f-1fbc-4c51-a482-621384b56698:
+                    required: true
+                    sortOrder: 2
+                  db0b8702-ef1b-409c-aa55-6de9d41d4d4a:
+                    required: false
+                    sortOrder: 1
+                  e2c780b8-c133-4e69-af2f-cee1076275cd:
+                    required: true
+                    sortOrder: 3
+                name: Merchandise
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: merchandise
+        hasTitleField: true
+        name: Merchandise
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: merchandise
     name: Merchandise
     propagateEntries: '1'
@@ -4040,41 +4040,41 @@ sections:
     enableVersioning: '1'
     entryTypes:
       3d29509c-9184-412b-902c-4628e3a3be5e:
-        name: Benefits
-        handle: benefits
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           c994ea54-d2b6-4f64-99b8-0b12898af37a:
             tabs:
               -
-                name: 'Benefits page content'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 3
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 4
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 5
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: 'Benefits page content'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: benefits
+        hasTitleField: true
+        name: Benefits
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: benefits
     name: Benefits
     propagateEntries: '1'
@@ -4094,44 +4094,44 @@ sections:
     enableVersioning: '1'
     entryTypes:
       b7d863c4-671d-492f-aba9-396925eff937:
-        name: Contact
-        handle: contact
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           df332a3d-7b02-4a23-bf98-f6328b7baaa0:
             tabs:
               -
-                name: 'Content Page'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: false
-                    sortOrder: 4
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 5
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 6
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: false
+                    sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: 'Content Page'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: contact
+        hasTitleField: true
+        name: Contact
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: contact
     name: Contact
     propagateEntries: '1'
@@ -4151,50 +4151,50 @@ sections:
     enableVersioning: '1'
     entryTypes:
       a0b8bcd6-c5a7-4c25-aad8-9fa8bdd9eca6:
-        name: 'Funding Guidance'
-        handle: fundingGuidance
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           79b47f10-cb80-4fb4-83a9-9b43d49de47b:
             tabs:
               -
-                name: Content
-                sortOrder: 1
                 fields:
-                  4bbbad71-25c1-4e25-9b13-8815cee1ee98:
-                    required: false
-                    sortOrder: 1
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: false
-                    sortOrder: 2
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 3
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 4
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                  4bbbad71-25c1-4e25-9b13-8815cee1ee98:
                     required: false
-                    sortOrder: 5
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 6
+                    sortOrder: 1
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 7
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 8
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 6
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 5
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: false
+                    sortOrder: 3
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: false
+                    sortOrder: 2
+                name: Content
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: fundingGuidance
+        hasTitleField: true
+        name: 'Funding Guidance'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: fundingGuidance
     name: 'Funding Guidance'
     propagateEntries: '1'
@@ -4217,47 +4217,47 @@ sections:
     enableVersioning: '1'
     entryTypes:
       3da0ca80-59b6-41e8-87c8-3658d9d2c3ea:
-        name: 'Project Stories'
-        handle: projectStories
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           e69e408d-fe6c-4f2d-bf36-2fce1836fbfa:
             tabs:
               -
-                name: 'Project story'
-                sortOrder: 1
                 fields:
-                  77ee3d71-5f00-486d-8593-1eea1a6e8cb4:
-                    required: false
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
-                    required: false
-                    sortOrder: 3
                   3b6db079-d2fc-4d40-b8d6-010fd64c8895:
                     required: false
                     sortOrder: 4
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: true
                     sortOrder: 5
-                  7234b38a-a7fc-4fbb-840f-c277d57f1ced:
-                    required: false
-                    sortOrder: 6
                   61aca7e9-75e9-4610-a0b5-39bb844a68c1:
                     required: true
                     sortOrder: 7
+                  7234b38a-a7fc-4fbb-840f-c277d57f1ced:
+                    required: false
+                    sortOrder: 6
+                  77ee3d71-5f00-486d-8593-1eea1a6e8cb4:
+                    required: false
+                    sortOrder: 1
+                  e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
+                    required: false
+                    sortOrder: 3
+                name: 'Project story'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: projectStories
+        hasTitleField: true
+        name: 'Project Stories'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: projectStories
     name: 'Project Stories'
     propagateEntries: '1'
@@ -4277,42 +4277,42 @@ sections:
     enableVersioning: '1'
     entryTypes:
       8f0f28b7-5dd3-4eb9-a71e-1e3f286f8085:
-        name: 'Our People'
-        handle: people
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           711fc888-e548-493d-8917-4bea84002fee:
             tabs:
               -
-                name: People
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
                   8c779db5-d5b9-4669-bb16-7749b921bc9b:
                     required: true
                     sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: People
+                sortOrder: 1
               -
-                name: Documents
-                sortOrder: 2
                 fields:
                   25308ee1-088a-4b07-83df-c7100eab536e:
                     required: false
                     sortOrder: 1
+                name: Documents
+                sortOrder: 2
               -
-                name: 'Social Media'
-                sortOrder: 3
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 3
+        handle: people
+        hasTitleField: true
+        name: 'Our People'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: people
     name: 'Our People'
     propagateEntries: '1'
@@ -4335,56 +4335,56 @@ sections:
     enableVersioning: '1'
     entryTypes:
       62073583-fc93-4b16-9081-a4d281bf6826:
-        name: 'Case Studies'
-        handle: caseStudies
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           1ae40b04-73c4-4578-b564-9cfbe42aaad1:
             tabs:
               -
-                name: 'Case Study'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
-                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
-                    required: false
-                    sortOrder: 2
-                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
-                    required: false
-                    sortOrder: 3
-                  ddea1520-060a-494e-95aa-f667a0f513e2:
-                    required: false
-                    sortOrder: 4
-                  ccddec99-6800-4547-afb4-022b00cf4915:
-                    required: true
-                    sortOrder: 5
-                  54f67d9c-5b73-4bb0-85e6-ca6d9949e03c:
-                    required: false
-                    sortOrder: 6
                   0cec86e6-ee99-4992-95ee-4044be2efd17:
                     required: true
                     sortOrder: 7
+                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
+                    required: false
+                    sortOrder: 3
                   1d64b0db-e29d-4232-b025-ff4793117dd8:
                     required: false
                     sortOrder: 8
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: false
                     sortOrder: 9
+                  54f67d9c-5b73-4bb0-85e6-ca6d9949e03c:
+                    required: false
+                    sortOrder: 6
                   8e813e66-eb51-4945-ba7b-013aa7d8b7d2:
                     required: false
                     sortOrder: 10
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: false
+                    sortOrder: 1
+                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
+                    required: false
+                    sortOrder: 2
+                  ccddec99-6800-4547-afb4-022b00cf4915:
+                    required: true
+                    sortOrder: 5
+                  ddea1520-060a-494e-95aa-f667a0f513e2:
+                    required: false
+                    sortOrder: 4
+                name: 'Case Study'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: caseStudies
+        hasTitleField: true
+        name: 'Case Studies'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: caseStudies
     name: 'Case Studies'
     propagateEntries: '1'
@@ -4404,38 +4404,38 @@ sections:
     enableVersioning: '1'
     entryTypes:
       8f2097a4-3a5d-4d38-9c35-b7a713c8758d:
-        name: 'About landing page'
-        handle: aboutLandingPage
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           f464d738-3a07-4b54-add6-d44116434ee2:
             tabs:
               -
-                name: About
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: true
                     sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: true
+                    sortOrder: 1
+                name: About
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: aboutLandingPage
+        hasTitleField: true
+        name: 'About landing page'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: aboutLandingPage
     name: 'About landing page'
     propagateEntries: '1'
@@ -4455,18 +4455,10 @@ sections:
     enableVersioning: '1'
     entryTypes:
       ca2c914a-7b86-4e18-885d-339d868d24d9:
-        name: Data
-        handle: data
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           fb473c93-ca03-4a7b-bc3f-06026d23fd5c:
             tabs:
               -
-                name: Data
-                sortOrder: 1
                 fields:
                   093b4dc3-16d8-439a-a963-39b9c9d7c164:
                     required: true
@@ -4474,13 +4466,21 @@ sections:
                   b1a844c2-594c-4e72-8523-a911d7b80f24:
                     required: true
                     sortOrder: 2
+                name: Data
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: data
+        hasTitleField: true
+        name: Data
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: data
     name: Data
     propagateEntries: '1'
@@ -4500,44 +4500,44 @@ sections:
     enableVersioning: '1'
     entryTypes:
       9b5463bd-6bf4-4da9-a732-56e3b5375b77:
-        name: 'Strategic investments in England'
-        handle: strategicInvestments
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           2e584ee6-1524-424c-abbf-2fd255b5f938:
             tabs:
               -
-                name: Content
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 4
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 5
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 6
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: false
+                    sortOrder: 1
+                name: Content
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: strategicInvestments
+        hasTitleField: true
+        name: 'Strategic investments in England'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: strategicInvestments
     name: 'Strategic investments in England'
     propagateEntries: '1'
@@ -4557,47 +4557,47 @@ sections:
     enableVersioning: '1'
     entryTypes:
       1320c236-b94a-4d47-aa7d-68a2aece2c01:
-        name: About
-        handle: about
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           82e54392-e2bd-4e3c-aa03-2c003082b499:
             tabs:
               -
-                name: 'Content Page'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: true
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 4
+                  46d0352f-42af-4d63-be4d-9c9df54c5871:
+                    required: false
+                    sortOrder: 7
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 5
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 6
-                  46d0352f-42af-4d63-be4d-9c9df54c5871:
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: true
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
                     required: false
-                    sortOrder: 7
+                    sortOrder: 1
+                name: 'Content Page'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: about
+        hasTitleField: true
+        name: About
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: about
     name: About
     propagateEntries: '1'
@@ -4649,44 +4649,44 @@ sections:
         titleFormat: null
         titleLabel: Title
       214caa6b-a341-4d7c-902d-7441c99c07ce:
-        name: 'Customer Service'
-        handle: customerService
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           948a33aa-c0ad-4dad-97bc-16bd549f184f:
             tabs:
               -
-                name: 'Content Page'
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
-                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
-                    required: true
-                    sortOrder: 4
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
                     sortOrder: 5
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
                     sortOrder: 6
+                  7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
+                    required: true
+                    sortOrder: 4
+                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
+                    required: false
+                    sortOrder: 1
+                name: 'Content Page'
+                sortOrder: 1
               -
-                name: 'Social Media'
-                sortOrder: 2
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: customerService
+        hasTitleField: true
+        name: 'Customer Service'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: customerService
     name: 'Customer Service'
     propagateEntries: '1'
@@ -4759,74 +4759,74 @@ sections:
     enableVersioning: '1'
     entryTypes:
       0a2d1a91-96ae-4fba-867f-62699822b0c6:
-        name: 'Strategic Programmes'
-        handle: strategicProgrammes
-        hasTitleField: true
-        titleLabel: Title
-        titleFormat: ''
-        sortOrder: 1
         fieldLayouts:
           8c2af0ed-5678-420f-a3a8-4c1d9a7ea622:
             tabs:
               -
-                name: Common
-                sortOrder: 1
                 fields:
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
-                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
-                    required: false
-                    sortOrder: 2
-                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
-                    required: false
-                    sortOrder: 3
-                  ccd71b86-6564-429f-972a-1def8e6840a4:
-                    required: true
-                    sortOrder: 4
-                  bcbf9339-ab42-4e3f-9db7-eaf3b499d36c:
-                    required: false
-                    sortOrder: 5
                   02eb210a-8b09-489c-994d-009c27b6167b:
                     required: false
                     sortOrder: 6
-              -
-                name: 'Aims & Learning'
-                sortOrder: 2
-                fields:
-                  dbfb641b-23fa-4110-969e-32cae11e39a9:
+                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
+                    required: false
+                    sortOrder: 3
+                  99eaaae9-87e0-4b54-a247-504431915423:
                     required: false
                     sortOrder: 1
+                  bcbf9339-ab42-4e3f-9db7-eaf3b499d36c:
+                    required: false
+                    sortOrder: 5
+                  c69c1ae1-4fa6-4bfb-9432-43367817a05a:
+                    required: false
+                    sortOrder: 2
+                  ccd71b86-6564-429f-972a-1def8e6840a4:
+                    required: true
+                    sortOrder: 4
+                name: Common
+                sortOrder: 1
+              -
+                fields:
                   607006ca-1479-43a1-9889-7ee63ef60289:
                     required: false
                     sortOrder: 2
-              -
-                name: Partners
-                sortOrder: 3
-                fields:
-                  4d5d77c6-2596-4418-85e9-822f7d1c7f67:
+                  dbfb641b-23fa-4110-969e-32cae11e39a9:
                     required: false
                     sortOrder: 1
+                name: 'Aims & Learning'
+                sortOrder: 2
+              -
+                fields:
                   065e680b-ad85-42eb-a1b2-6623e8233466:
                     required: false
                     sortOrder: 2
+                  4d5d77c6-2596-4418-85e9-822f7d1c7f67:
+                    required: false
+                    sortOrder: 1
                   7d911d3c-651d-4c2c-ae62-a64b0f554bb0:
                     required: false
                     sortOrder: 3
+                name: Partners
+                sortOrder: 3
               -
-                name: Resources
-                sortOrder: 4
                 fields:
                   816a3589-836c-4201-9d84-8d77a93a52a8:
                     required: false
                     sortOrder: 1
+                name: Resources
+                sortOrder: 4
               -
-                name: 'Social Media'
-                sortOrder: 5
                 fields:
                   6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
                     required: false
                     sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 5
+        handle: strategicProgrammes
+        hasTitleField: true
+        name: 'Strategic Programmes'
+        sortOrder: 1
+        titleFormat: ''
+        titleLabel: Title
     handle: strategicProgrammes
     name: 'Strategic Programmes'
     propagateEntries: '1'

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -7,7 +7,7 @@ use craft\elements\Entry;
 
 class ContentHelpers
 {
-    public static function getCommonFields(Entry $entry, $status, $locale, $skipHeroes = false)
+    public static function getCommonFields(Entry $entry, $status, $locale, $includeHeroes = true)
     {
         $fields = [
             'id' => $entry->id,
@@ -29,7 +29,7 @@ class ContentHelpers
         ];
         $extraFields = [];
 
-        if (!$skipHeroes) {
+        if ($includeHeroes) {
             // Looking up heroes is expensive for some API calls (eg. listing all funding programmes)
             // so we allow them to be optional
             $extraFields = [

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -7,9 +7,9 @@ use craft\elements\Entry;
 
 class ContentHelpers
 {
-    public static function getCommonFields(Entry $entry, $status, $locale)
+    public static function getCommonFields(Entry $entry, $status, $locale, $skipHeroes = false)
     {
-        return [
+        $fields = [
             'id' => $entry->id,
             'entryType' => $entry->type->handle,
             'slug' => $entry->slug,
@@ -25,10 +25,20 @@ class ContentHelpers
             'linkUrl' => $entry->externalUrl ? $entry->externalUrl : EntryHelpers::uriForLocale($entry->uri, $locale),
             'title' => $entry->title,
             'trailText' => $entry->trailText ?? null,
-            'hero' => $entry->heroImage ? Images::extractHeroImage($entry->heroImage) : null,
-            'heroCredit' => $entry->heroImageCredit ?? null,
-            'heroNew' => Images::buildHero($entry->hero),
         ];
+        $extraFields = [];
+
+        if (!$skipHeroes) {
+            // Looking up heroes is expensive for some API calls (eg. listing all funding programmes)
+            // so we allow them to be optional
+            $extraFields = [
+                'hero' => $entry->heroImage ? Images::extractHeroImage($entry->heroImage) : null,
+                'heroCredit' => $entry->heroImageCredit ?? null,
+                'heroNew' => Images::buildHero($entry->hero),
+            ];
+        }
+
+        return array_merge($fields, $extraFields);
     }
 
     public static function nestedCategorySummary($categories, $locale)

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -29,7 +29,7 @@ class FundingProgrammeTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale, $skipHeroes = !$this->isSingle);
+        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale, $includeHeroes = $this->isSingle);
 
         $commonProgrammeFields = [
                 'isArchived' => $commonFields['status'] === 'expired' && $entry->legacyPath !== null,

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -10,9 +10,10 @@ use League\Fractal\TransformerAbstract;
 
 class FundingProgrammeTransformer extends TransformerAbstract
 {
-    public function __construct($locale)
+    public function __construct($locale, $isSingle = false)
     {
         $this->locale = $locale;
+        $this->isSingle = $isSingle;
     }
 
     private static function buildTrailImage($imageField)
@@ -28,39 +29,47 @@ class FundingProgrammeTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale, $skipHeroes = !$this->isSingle);
 
-        return array_merge($commonFields, [
-            'isArchived' => $commonFields['status'] === 'expired' && $entry->legacyPath !== null,
-            'description' => $entry->programmeIntro ?? null,
-            'footer' => $entry->outroText ?? null,
-            'thumbnail' => ContentHelpers::getFundingProgrammeThumbnailUrl($entry),
-            'thumbnailNew' => ContentHelpers::getFundingProgrammeThumbnailUrlNew($entry),
-            'trailImage' => self::buildTrailImage($entry->heroImage->one()),
-            'trailImageNew' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
-            'contentSections' => array_map(function ($block) {
-                return [
-                    'title' => $block->programmeRegionTitle,
-                    'body' => $block->programmeRegionBody,
-                ];
-            }, $entry->programmeRegions->all() ?? []),
-            'area' => $entry->programmeArea ? [
-                'label' => EntryHelpers::translate($this->locale, $entry->programmeArea->label),
-                'value' => $entry->programmeArea->value,
-            ] : null,
-            'fundingSize' => [
-                'minimum' => $entry->minimumFundingSize ? (int) $entry->minimumFundingSize : null,
-                'maximum' => $entry->maximumFundingSize ? (int) $entry->maximumFundingSize : null,
-                'totalAvailable' => $entry->totalFundingAvailable ?? null,
-                'description' => $entry->fundingSizeDescription ?? null,
-            ],
-            'applicationDeadline' => $entry->applicationDeadline ?? null,
-            'organisationType' => $entry->organisationType ?? null,
-            'legacyPath' => $entry->legacyPath ?? null,
-            'projectStories' => array_map(function ($entry) {
-                $transformer = new ProjectStoriesTransformer($this->locale);
-                return $transformer->transform($entry);
-            }, $entry->relatedProjectStories ? $entry->relatedProjectStories->all() : [])
-        ]);
+        $commonProgrammeFields = [
+                'isArchived' => $commonFields['status'] === 'expired' && $entry->legacyPath !== null,
+                'description' => $entry->programmeIntro ?? null,
+                'thumbnail' => ContentHelpers::getFundingProgrammeThumbnailUrl($entry),
+                'thumbnailNew' => ContentHelpers::getFundingProgrammeThumbnailUrlNew($entry),
+                'trailImage' => self::buildTrailImage($entry->heroImage->one()),
+                'trailImageNew' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
+                'area' => $entry->programmeArea ? [
+                    'label' => EntryHelpers::translate($this->locale, $entry->programmeArea->label),
+                    'value' => $entry->programmeArea->value,
+                ] : null,
+                'fundingSize' => [
+                    'minimum' => $entry->minimumFundingSize ? (int) $entry->minimumFundingSize : null,
+                    'maximum' => $entry->maximumFundingSize ? (int) $entry->maximumFundingSize : null,
+                    'totalAvailable' => $entry->totalFundingAvailable ?? null,
+                    'description' => $entry->fundingSizeDescription ?? null,
+                ],
+                'applicationDeadline' => $entry->applicationDeadline ?? null,
+                'organisationType' => $entry->organisationType ?? null,
+                'legacyPath' => $entry->legacyPath ?? null,
+        ];
+
+        if (!$this->isSingle) {
+            return array_merge($commonFields, $commonProgrammeFields);
+        } else {
+            // Add in the content fields for single programme display
+            return array_merge($commonFields, $commonProgrammeFields, [
+                'footer' => $entry->outroText ?? null,
+                'contentSections' => array_map(function ($block) {
+                    return [
+                        'title' => $block->programmeRegionTitle,
+                        'body' => $block->programmeRegionBody,
+                    ];
+                }, $entry->programmeRegions->all() ?? []),
+                'projectStories' => array_map(function ($entry) {
+                    $transformer = new ProjectStoriesTransformer($this->locale);
+                    return $transformer->transform($entry);
+                }, $entry->relatedProjectStories ? $entry->relatedProjectStories->all() : [])
+            ]);
+        }
     }
 }


### PR DESCRIPTION
A few things here:

- adds a way to request a specific number of "latest" programmes for the funding landing page (rather than fetching them all and then filtering to a specific 3)

- limits the fields that are returned for listing lookups versus single pages (eg. hero lookups were especially slow)

|                               | Load time (ms) | Size (KB) |
|-------------------------------|----------------|-----------|
| Programme list (before)       | 3000           | 313kb     |
| Programme list (after)        | 1500           | 53kb      |


Things that are still slow: the listing of all programmes. Doesn't help that each time we fetch this list we fetch it a second time (for Welsh) and merge them in. Not sure how we can fix this though.