### PR TITLE
Add an introduction field for gridblocks

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1554366810
+dateModified: 1554375949
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -3001,15 +3001,36 @@ matrixBlockTypes:
         tabs:
           -
             fields:
+              4a787c27-6078-43fb-a29e-8a61cf61d97c:
+                required: false
+                sortOrder: 2
               78a83748-7862-4217-b345-e40cf81a05c4:
                 required: true
-                sortOrder: 2
+                sortOrder: 3
               9d18c90a-d7c7-40f9-ba89-9aa374932cf9:
                 required: false
                 sortOrder: 1
             name: Content
             sortOrder: 1
     fields:
+      4a787c27-6078-43fb-a29e-8a61cf61d97c:
+        contentColumnType: text
+        fieldGroup: null
+        handle: introduction
+        instructions: 'The content you wish to appear before the grid blocks'
+        name: Introduction
+        searchable: true
+        settings:
+          availableTransforms: '*'
+          availableVolumes: '*'
+          cleanupHtml: '1'
+          columnType: text
+          purifierConfig: safe-iframe-media.json
+          purifyHtml: '1'
+          redactorConfig: Full.json
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\redactor\Field
       78a83748-7862-4217-b345-e40cf81a05c4:
         contentColumnType: string
         fieldGroup: null
@@ -3019,9 +3040,9 @@ matrixBlockTypes:
         searchable: true
         settings:
           columns:
-            332:
+            253:
               width: ''
-          contentTable: '{{%stc_30_blocks}}'
+          contentTable: '{{%stc_25_blocks}}'
           fieldLayout: matrix
           localizeBlocks: '1'
           maxRows: ''

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -159,6 +159,7 @@ class ContentHelpers
                     $gridBlocks = array();
                     $data = [
                         'type' => $block->type->handle,
+                        'introduction' => $block->introduction ?? null,
                         'title' => $block->flexTitle ?? null,
                     ];
                     if (!empty($block->blocks->all())) {


### PR DESCRIPTION
Grid blocks were meant to have introductions but I think I lost them during merge hell.

![image](https://user-images.githubusercontent.com/394376/55638537-581a4f00-57bf-11e9-8740-5b1674e143cb.png)

Unfortunately my efforts to ship this yesterday (directly on `master` 🙈) failed due to project config sync errors when deployed to TEST – this seems to be another variation of the issues deploying anything that changes a SuperTable field.

I suspect we may need to spin up a new CMS instance with a new database and do a bunch of upgrades at once (possibly enabling admin changes on that environment, temporarily) so we can get past this – later SuperTable/Craft versions seem to have improved this side of things.