### PR TITLE
Begin removing old hero image fields from CMS

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1557223197
+dateModified: 1557223333
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -4701,13 +4701,10 @@ sections:
                 fields:
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
-                    sortOrder: 2
+                    sortOrder: 1
                   8c779db5-d5b9-4669-bb16-7749b921bc9b:
                     required: true
-                    sortOrder: 3
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
+                    sortOrder: 2
                 name: People
                 sortOrder: 1
               -

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1557222918
+dateModified: 1557223197
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -4984,25 +4984,22 @@ sections:
                 fields:
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
-                    sortOrder: 2
+                    sortOrder: 1
                   46d0352f-42af-4d63-be4d-9c9df54c5871:
                     required: false
-                    sortOrder: 7
+                    sortOrder: 6
                   6c792519-1c25-4194-a0e5-60377539e790:
                     required: false
-                    sortOrder: 5
+                    sortOrder: 4
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
-                    sortOrder: 6
+                    sortOrder: 5
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: true
-                    sortOrder: 4
+                    sortOrder: 3
                   7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
                     required: true
-                    sortOrder: 3
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: false
-                    sortOrder: 1
+                    sortOrder: 2
                 name: 'Content Page'
                 sortOrder: 1
               -

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1554823927
+dateModified: 1557222918
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -4087,22 +4087,19 @@ sections:
                 fields:
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
-                    sortOrder: 2
+                    sortOrder: 1
                   4b573749-5271-405a-9d27-9e086ee1f31f:
                     required: false
-                    sortOrder: 5
+                    sortOrder: 4
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: true
-                    sortOrder: 4
+                    sortOrder: 3
                   83a59f94-8342-417f-b427-11c3c162d89e:
                     required: true
-                    sortOrder: 6
-                  99eaaae9-87e0-4b54-a247-504431915423:
-                    required: true
-                    sortOrder: 1
+                    sortOrder: 5
                   ccd71b86-6564-429f-972a-1def8e6840a4:
                     required: true
-                    sortOrder: 3
+                    sortOrder: 2
                 name: 'Main content'
                 sortOrder: 1
               -

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -13,22 +13,18 @@ class ResearchTransformer extends TransformerAbstract
         $this->locale = $locale;
     }
 
-    private static function buildTrailImage($imageField)
-    {
-        return $imageField ? Images::imgixUrl(
-            $imageField->imageMedium->one()->url,
-            ['w' => '640', 'h' => '360']
-        ) : null;
-    }
-
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
+
         $researchMeta = $entry->researchMeta->one();
+        $heroField = Images::extractNewHeroImageField($entry->hero);
+
         return array_merge(ContentHelpers::getCommonFields($entry, $status, $this->locale), [
-            // @TODO: Remove thumbnail in favour of trailImage once all pages have new hero images
-            'thumbnail' => self::buildTrailImage(Images::extractImage($entry->heroImage)),
-            'trailImage' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
+            'trailImage' => $heroField ? Images::imgixUrl(
+                $heroField->imageMedium->one()->url,
+                ['w' => '640', 'h' => '360']
+            ) : null,
 
             'introduction' => $entry->introductionText ?? null,
             'contactEmail' => $researchMeta ? $researchMeta->contactEmail : null,


### PR DESCRIPTION
Begin removing old hero image fields from CMS. Remove from: Insights, about sub-pages, our people.