### PR TITLE
Fix Insight Document search

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -237,7 +237,8 @@ function getResearch($locale, $type = false)
     ];
 
     $sortParam = \Craft::$app->request->getParam('sort');
-    if ($searchQuery = \Craft::$app->request->getParam('q') && ($sortParam === 'score' || !$sortParam)) {
+    $searchQuery = \Craft::$app->request->getParam('q');
+    if ($searchQuery && ($sortParam === 'score' || !$sortParam)) {
         $criteria['orderBy'] = 'score';
         $criteria['search'] = [
             'query' => $searchQuery,


### PR DESCRIPTION
Embarrassingly, the way I'd structured this code meant that any search query was using the existence of the query (eg. `true`) as the search term, rather than whatever the query actually was. This change restores balance to the universe.