### PR TITLE
Allow BBO pages to use Flexible Content

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1562153947
+dateModified: 1563179858
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -3853,10 +3853,13 @@ sections:
                 fields:
                   0ffe78fe-8cab-4c76-a558-5dcb3cb2dd34:
                     required: false
-                    sortOrder: 4
+                    sortOrder: 5
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 2
+                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
+                    required: false
+                    sortOrder: 4
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: true
                     sortOrder: 3


### PR DESCRIPTION
This is required for BBO subpages so we can make this layout:

![blf local_3000_funding_programmes_building-better-opportunities_black-country](https://user-images.githubusercontent.com/394376/61205170-419d6100-a6e7-11e9-84d8-5a0e76e33d96.png)
