### PR TITLE
Ensure press releases require some content

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1564995065
+dateModified: 1565258274
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -4370,7 +4370,7 @@ sections:
                     required: false
                     sortOrder: 12
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
-                    required: false
+                    required: true
                     sortOrder: 9
                   419ecf2d-b6f9-4754-a309-88579895b504:
                     required: false


### PR DESCRIPTION
Just had a call from someone who put their press release content in the "Contacts" field instead of "Content", which saved successfully, but showed a 404 on production. Turns out the flexible content field wasn't required(!) for press releases. Fixed it!