### PR TITLE
Add funding section

### DIFF
--- a/config/general.php
+++ b/config/general.php
@@ -41,7 +41,7 @@ return [
     // Dev environment settings
     'dev' => [
         // Base site URL
-        'siteUrl' => null,
+        'siteUrl' => getenv('SITE_URL'),
 
         // Dev Mode (see https://craftcms.com/support/dev-mode)
         'devMode' => true,

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1570194618
+dateModified: 1571307695
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -3869,29 +3869,29 @@ matrixBlockTypes:
     sortOrder: 1
 plugins:
   aws-s3:
-    enabled: '1'
+    enabled: true
     licenseKey: null
     schemaVersion: '1.2'
     settings: null
   cp-css:
-    enabled: '1'
+    enabled: true
     licenseKey: null
     schemaVersion: 2.0.0
     settings:
       additionalCss: ''
       cssFile: /resources/css/cp.css
   cp-js:
-    enabled: '1'
+    enabled: true
     licenseKey: null
     schemaVersion: 2.0.0
     settings: null
   element-api:
-    enabled: '1'
+    enabled: true
     licenseKey: null
     schemaVersion: 1.0.0
     settings: null
   element-map:
-    enabled: '1'
+    enabled: true
     licenseKey: null
     schemaVersion: 1.0.0
     settings: null
@@ -3917,12 +3917,12 @@ plugins:
     enabled: true
     schemaVersion: 2.0.0
   recentchanges:
-    enabled: '1'
+    enabled: true
     licenseKey: null
     schemaVersion: 1.0.0
     settings: null
   redactor:
-    enabled: '1'
+    enabled: true
     licenseKey: null
     schemaVersion: 2.3.0
     settings: null
@@ -3932,12 +3932,12 @@ plugins:
     schemaVersion: 1.0.0
     settings: null
   super-table:
-    enabled: '1'
+    enabled: true
     licenseKey: null
     schemaVersion: 2.2.0
     settings: null
   tag-manager:
-    enabled: '1'
+    enabled: true
     licenseKey: null
     schemaVersion: 1.0.0
     settings: null
@@ -5478,6 +5478,57 @@ sections:
       uid: b499b2f0-3599-4386-8b87-801027fab3f6
     type: structure
     propagationMethod: all
+  fe6c1cbb-359d-4fe3-92d9-b5c1aec35783:
+    name: Funding
+    handle: funding
+    type: structure
+    enableVersioning: true
+    propagationMethod: all
+    siteSettings:
+      81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
+        enabledByDefault: true
+        hasUrls: true
+        uriFormat: '{parent.uri ? parent.uri : ''funding''}/{slug}'
+        template: ''
+      d0635f95-a563-4f66-9195-33da0eb644d5:
+        enabledByDefault: true
+        hasUrls: true
+        uriFormat: '{parent.uri ? parent.uri : ''funding''}/{slug}'
+        template: ''
+    structure:
+      uid: e166e603-46ac-461c-8480-ffc5dd4482a1
+      maxLevels: null
+    entryTypes:
+      9c272981-2512-4e3e-9555-e3b161c5b5a7:
+        name: Funding
+        handle: funding
+        hasTitleField: true
+        titleLabel: Title
+        titleFormat: ''
+        sortOrder: 1
+        fieldLayouts:
+          26c3b5f6-f1a3-464e-88b5-ad3baeaf6ceb:
+            tabs:
+              -
+                name: Content
+                sortOrder: 1
+                fields:
+                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
+                    required: false
+                    sortOrder: 1
+                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
+                    required: true
+                    sortOrder: 2
+                  7234b38a-a7fc-4fbb-840f-c277d57f1ced:
+                    required: false
+                    sortOrder: 3
+              -
+                name: 'Social Media'
+                sortOrder: 2
+                fields:
+                  6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
+                    required: false
+                    sortOrder: 1
 siteGroups:
   ea0f6303-e72a-4088-bfb5-82489efb3267:
     name: 'The National Lottery Community Fund'

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1571307695
+dateModified: 1571393950
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -475,6 +475,31 @@ fields:
     translationKeyFormat: null
     translationMethod: language
     type: craft\fields\PlainText
+  3cfdb7b7-949e-4841-b88d-148f1ea0b289:
+    name: 'Child page display'
+    handle: childPageDisplay
+    instructions: "How should child pages of this page be displayed?\n\nNote: photo grids will only display if each child page has a hero image."
+    searchable: false
+    translationMethod: none
+    translationKeyFormat: null
+    type: craft\fields\Dropdown
+    settings:
+      optgroups: true
+      options:
+        -
+          label: 'Do not show child pages'
+          value: none
+          default: '1'
+        -
+          label: 'Show child pages as a photo grid'
+          value: grid
+          default: ''
+        -
+          label: 'Show child pages as a list of text links'
+          value: list
+          default: ''
+    contentColumnType: string
+    fieldGroup: 1770279d-fae8-42d7-9209-2e4e311f9e8a
   3d1305a6-366b-4a1d-8849-433df83a803e:
     contentColumnType: string
     fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
@@ -5516,6 +5541,9 @@ sections:
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 1
+                  3cfdb7b7-949e-4841-b88d-148f1ea0b289:
+                    required: false
+                    sortOrder: 4
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: true
                     sortOrder: 2

--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -87,6 +87,7 @@ class ListingTransformer extends TransformerAbstract
             }, $entry->contentSegment->all() ?? []) : [],
             'flexibleContent' => ContentHelpers::extractFlexibleContent($entry, $this->locale),
             'outro' => $entry->outroText ?? null,
+            'childPageDisplay' => $entry->childPageDisplay ? $entry->childPageDisplay->value : null,
         ];
 
         $ancestors = self::getRelatedEntries($entry, 'ancestors');


### PR DESCRIPTION
This is quite a meaty bit of work, pairing with a frontend change. 

The idea is a bit of a do-over on how CMS content should work, generally. The goal here was to create a new section which **only** uses flexible content, supports child pages to arbitrary levels, and allows customisation of how those children are displayed on the parent page.

The goal is for the new/revamped Funding section to work under this structure. Mocked up locally like this:

![image](https://user-images.githubusercontent.com/394376/67088752-d8bdfd00-f19d-11e9-96c9-facc572bdd0c.png)

There's a dropdown at the end of the Entry editor which allows customising how child pages appear:

![image](https://user-images.githubusercontent.com/394376/67088786-e8d5dc80-f19d-11e9-8183-83290e39ecc7.png)
