### PR TITLE
Give preview links a lifespan of a week, not a day

### DIFF
--- a/config/general.php
+++ b/config/general.php
@@ -36,6 +36,9 @@ return [
         // This needs to be defined if upload_max_filesize is greater than 16mb (Craft default)
         'maxUploadFileSize' => 20777216,
 
+        // Allow expiring links (eg. shareable previews) to last for a week
+        'defaultTokenDuration ' => 604800, // one week
+
     ],
 
     // Dev environment settings


### PR DESCRIPTION
A day is a bit short for a preview link to stop working, so let's make it a week.

This may or may not affect other token links like password resets / account activations – a week is probably just-about okay for these, but no-expiry would probably be too much.