### PR TITLE
Don't fetch programme images for /all endpoint

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -165,12 +165,13 @@ function getFundingProgrammes($locale, $programmeSlug = null, $childPageSlug = n
     ];
 
     $isSingle = $programmeSlug || $childPageSlug;
+    $showAllProgrammes = \Craft::$app->request->getParam('all') === 'true';
 
     if ($isSingle) {
         // First look for child pages, then defer to the parent programme
         $criteria['slug'] = $childPageSlug ? $childPageSlug : $programmeSlug;
         $criteria['status'] = EntryHelpers::getVersionStatuses();
-    } else if (\Craft::$app->request->getParam('all') === 'true') {
+    } else if ($showAllProgrammes) {
         $criteria['orderBy'] = 'title asc';
         $criteria['status'] = ['live', 'expired'];
     } else if (\Craft::$app->request->getParam('newest') === 'true') {
@@ -191,7 +192,7 @@ function getFundingProgrammes($locale, $programmeSlug = null, $childPageSlug = n
         'criteria' => $criteria,
         'one' => $isSingle,
         'elementsPerPage' => \Craft::$app->request->getParam('page-limit') ?: 100,
-        'transformer' => new FundingProgrammeTransformer($locale, $isSingle)
+        'transformer' => new FundingProgrammeTransformer($locale, $isSingle, $showAllProgrammes)
     ];
 }
 

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -10,11 +10,11 @@ use League\Fractal\TransformerAbstract;
 
 class FundingProgrammeTransformer extends TransformerAbstract
 {
-    public function __construct($locale, $isSingle = false, $showAllProgrammes = false)
+    public function __construct($locale, $isSingle = false, $includeImages = false)
     {
         $this->locale = $locale;
         $this->isSingle = $isSingle;
-        $this->showAllProgrammes = $showAllProgrammes;
+        $this->includeImages = $includeImages;
     }
 
     private static function buildTrailImage($imageField)
@@ -54,7 +54,7 @@ class FundingProgrammeTransformer extends TransformerAbstract
             ];
 
             if (!$this->isSingle) {
-                if ($this->showAllProgrammes) {
+                if ($this->includeImages) {
                     return array_merge($commonFields, $commonProgrammeFields);
                 } else {
                     $imageFields = [

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -10,10 +10,11 @@ use League\Fractal\TransformerAbstract;
 
 class FundingProgrammeTransformer extends TransformerAbstract
 {
-    public function __construct($locale, $isSingle = false)
+    public function __construct($locale, $isSingle = false, $showAllProgrammes = false)
     {
         $this->locale = $locale;
         $this->isSingle = $isSingle;
+        $this->showAllProgrammes = $showAllProgrammes;
     }
 
     private static function buildTrailImage($imageField)
@@ -37,10 +38,6 @@ class FundingProgrammeTransformer extends TransformerAbstract
             $commonProgrammeFields = [
                 'isArchived' => $commonFields['status'] === 'expired' && $entry->legacyPath !== null,
                 'description' => $entry->programmeIntro ?? null,
-                'thumbnail' => ContentHelpers::getFundingProgrammeThumbnailUrl($entry),
-                'thumbnailNew' => ContentHelpers::getFundingProgrammeThumbnailUrlNew($entry),
-                'trailImage' => $entry->heroImage ? self::buildTrailImage($entry->heroImage->one()) : null,
-                'trailImageNew' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
                 'area' => $entry->programmeArea ? [
                     'label' => EntryHelpers::translate($this->locale, $entry->programmeArea->label),
                     'value' => $entry->programmeArea->value,
@@ -57,7 +54,17 @@ class FundingProgrammeTransformer extends TransformerAbstract
             ];
 
             if (!$this->isSingle) {
-                return array_merge($commonFields, $commonProgrammeFields);
+                if ($this->showAllProgrammes) {
+                    return array_merge($commonFields, $commonProgrammeFields);
+                } else {
+                    $imageFields = [
+                        'thumbnail' => ContentHelpers::getFundingProgrammeThumbnailUrl($entry),
+                        'thumbnailNew' => ContentHelpers::getFundingProgrammeThumbnailUrlNew($entry),
+                        'trailImage' => $entry->heroImage ? self::buildTrailImage($entry->heroImage->one()) : null,
+                        'trailImageNew' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero))
+                    ];
+                    return array_merge($commonFields, $commonProgrammeFields, $imageFields);
+                }
             } else {
                 // Add in the content fields for single programme display
                 return array_merge($commonFields, $commonProgrammeFields, [


### PR DESCRIPTION
Including thumbnails/heroes for programme pages was spiking CPU for the CMS API – removing them when rendering the `/funding/programmes/all` page speeds up the CMS response and hopefully reduces the chance of a 504 timeout at the website end. We don't use the images on the `/all` list so it's safe to remove them here.

### Before
![image](https://user-images.githubusercontent.com/394376/67850415-418f6880-fb00-11e9-8d18-fc126e4e0a09.png)

### After
![image](https://user-images.githubusercontent.com/394376/67850431-46541c80-fb00-11e9-8c3f-a0156b342381.png)
