### PR TITLE
Add Flexible Content Next features

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1571393950
+dateModified: 1572518371
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -3785,6 +3785,80 @@ matrixBlockTypes:
                 required: false
                 sortOrder: 3
               f9c3f7a5-d574-4be1-b35a-da174c68b4b8:
+                required: false
+                sortOrder: 1
+  f61ad888-6ae7-4c9f-ab43-f7a3ed6c76da:
+    field: 40755bc8-380a-49b7-9f5b-786c5e1e6bbe
+    name: 'Table of Contents'
+    handle: tableOfContents
+    sortOrder: 7
+    fields:
+      173fd2cb-0f50-4807-ac9b-7af40f73e7ca:
+        name: 'Table of Contents introduction'
+        handle: tableOfContentsIntro
+        instructions: 'Place this block where you''d like your Table of Contents (TOC) to appear. If your other Flexible Content blocks have Titles, they''ll appear in your TOC. You can add text here to appear above the TOC.'
+        searchable: false
+        translationMethod: site
+        translationKeyFormat: null
+        type: craft\redactor\Field
+        settings:
+          redactorConfig: Full.json
+          purifierConfig: ''
+          cleanupHtml: true
+          removeInlineStyles: '1'
+          removeEmptyTags: '1'
+          removeNbsp: '1'
+          purifyHtml: '1'
+          columnType: text
+          availableVolumes: '*'
+          availableTransforms: '*'
+        contentColumnType: text
+        fieldGroup: null
+    fieldLayouts:
+      e51405f2-fcb8-4e77-9b2a-57e786130311:
+        tabs:
+          -
+            name: Content
+            sortOrder: 1
+            fields:
+              173fd2cb-0f50-4807-ac9b-7af40f73e7ca:
+                required: false
+                sortOrder: 1
+  f76c4d99-f62f-463b-b573-946becc0923d:
+    field: 40755bc8-380a-49b7-9f5b-786c5e1e6bbe
+    name: 'Child Page List'
+    handle: childPageList
+    sortOrder: 8
+    fields:
+      e86eb7e9-f5e2-4185-8c86-f76acce0b3ca:
+        name: 'Child page display style'
+        handle: childPageDisplayStyle
+        instructions: 'Place this block where you''d like child pages to be displayed. Choose how they should be displayed:'
+        searchable: false
+        translationMethod: site
+        translationKeyFormat: null
+        type: craft\fields\Dropdown
+        settings:
+          optgroups: true
+          options:
+            -
+              label: 'Text list'
+              value: list
+              default: '1'
+            -
+              label: 'Photo grid'
+              value: grid
+              default: ''
+        contentColumnType: string
+        fieldGroup: null
+    fieldLayouts:
+      aa35dd33-d70e-4bca-9e52-801a628ee678:
+        tabs:
+          -
+            name: Content
+            sortOrder: 1
+            fields:
+              e86eb7e9-f5e2-4185-8c86-f76acce0b3ca:
                 required: false
                 sortOrder: 1
   fa1bc12d-a0f6-4d83-a213-cb9a9ca82eb5:

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1572518371
+dateModified: 1572521575
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -475,31 +475,6 @@ fields:
     translationKeyFormat: null
     translationMethod: language
     type: craft\fields\PlainText
-  3cfdb7b7-949e-4841-b88d-148f1ea0b289:
-    name: 'Child page display'
-    handle: childPageDisplay
-    instructions: "How should child pages of this page be displayed?\n\nNote: photo grids will only display if each child page has a hero image."
-    searchable: false
-    translationMethod: none
-    translationKeyFormat: null
-    type: craft\fields\Dropdown
-    settings:
-      optgroups: true
-      options:
-        -
-          label: 'Do not show child pages'
-          value: none
-          default: '1'
-        -
-          label: 'Show child pages as a photo grid'
-          value: grid
-          default: ''
-        -
-          label: 'Show child pages as a list of text links'
-          value: list
-          default: ''
-    contentColumnType: string
-    fieldGroup: 1770279d-fae8-42d7-9209-2e4e311f9e8a
   3d1305a6-366b-4a1d-8849-433df83a803e:
     contentColumnType: string
     fieldGroup: 24b26cf1-ecc7-44ee-a2d5-0f1de62055cf
@@ -5615,15 +5590,9 @@ sections:
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
                     sortOrder: 1
-                  3cfdb7b7-949e-4841-b88d-148f1ea0b289:
-                    required: false
-                    sortOrder: 4
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: true
                     sortOrder: 2
-                  7234b38a-a7fc-4fbb-840f-c277d57f1ced:
-                    required: false
-                    sortOrder: 3
               -
                 name: 'Social Media'
                 sortOrder: 2

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -8,6 +8,16 @@ use craft\elements\Entry;
 class ContentHelpers
 {
 
+    private static function allPagesHaveImages(array $pages)
+    {
+        foreach ($pages as $page) {
+            if (!$page['trailImage']) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static function buildTrailImage($imageField)
     {
         $photoUrl = $imageField ? Images::extractImageUrl($imageField) : null;
@@ -130,7 +140,7 @@ class ContentHelpers
      * - Inline figure (image with a caption)
      * - Media aside (callout block with text, image, and link)
      */
-    public static function extractFlexibleContent(Entry $entry, $locale)
+    public static function extractFlexibleContent(Entry $entry, $locale, $children = null)
     {
         $parts = [];
         if (!$entry->flexibleContent) {
@@ -226,11 +236,17 @@ class ContentHelpers
                     array_push($parts, $data);
                     break;
                 case 'childPageList':
-                    $data = [
-                        'type' => $block->type->handle,
-                        'displayMode' => $block->childPageDisplayStyle->value
-                    ];
-                    array_push($parts, $data);
+                    if (count($children) > 0) {
+                        // Work out if we can display a grid of photos
+                        $allPagesHaveImages = self::allPagesHaveImages($children);
+                        $desiredDisplayMode = $block->childPageDisplayStyle->value;
+                        $displayMode = ($desiredDisplayMode === 'grid' && $allPagesHaveImages) ? 'grid' : 'list';
+                        $data = [
+                            'type' => $block->type->handle,
+                            'displayMode' => $displayMode,
+                        ];
+                        array_push($parts, $data);
+                    }
                     break;
             }
         }

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -218,6 +218,20 @@ class ContentHelpers
                     $data['content'] = $gridBlocks;
                     array_push($parts, $data);
                     break;
+                case 'tableOfContents':
+                    $data = [
+                        'type' => $block->type->handle,
+                        'content' => $block->tableOfContentsIntro ?? null
+                    ];
+                    array_push($parts, $data);
+                    break;
+                case 'childPageList':
+                    $data = [
+                        'type' => $block->type->handle,
+                        'displayMode' => $block->childPageDisplayStyle->value
+                    ];
+                    array_push($parts, $data);
+                    break;
             }
         }
         return $parts;

--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -85,9 +85,7 @@ class ListingTransformer extends TransformerAbstract
                     'photo' => $segmentImage ? $segmentImage->url : null,
                 ];
             }, $entry->contentSegment->all() ?? []) : [],
-            'flexibleContent' => ContentHelpers::extractFlexibleContent($entry, $this->locale),
-            'outro' => $entry->outroText ?? null,
-            'childPageDisplay' => $entry->childPageDisplay ? $entry->childPageDisplay->value : null,
+            'outro' => $entry->outroText ?? null
         ];
 
         $ancestors = self::getRelatedEntries($entry, 'ancestors');
@@ -104,6 +102,10 @@ class ListingTransformer extends TransformerAbstract
         if (count($siblings) > 0) {
             $customFields['siblings'] = $siblings;
         }
+
+        // Finally construct flexible content, which depends upon some of the above fields
+        $customFields['flexibleContent'] = ContentHelpers::extractFlexibleContent($entry, $this->locale, $children);
+
 
         return array_merge($commonFields, $customFields);
     }


### PR DESCRIPTION
Adds two new flexible content block types:

![image](https://user-images.githubusercontent.com/394376/67944919-9b159700-fbd5-11e9-86aa-c9a4c6eb058d.png)

### Table of Contents

![image](https://user-images.githubusercontent.com/394376/67944938-a7015900-fbd5-11e9-8d2b-9b8d302048d8.png)

### Child Page list

![image](https://user-images.githubusercontent.com/394376/67944931-a1a40e80-fbd5-11e9-9429-d0ea31b28593.png)

When paired with the new frontend template changes, this means that users can add these blocks to control the positioning of these elements rather than rely on hard-coded and slightly opaque implicit template calls, eg. having the site auto-append TOCs after the first element or child pages after the last one etc.

Tradeoff is the potential for silly/accidental content choices like duplicate TOCs/child page lists, or positioning a TOC at the end of the page etc, but we can potentially catch these and display warnings when in preview mode (perhaps a wider piece of work generally).