### PR TITLE
Allow external links to be used for flexible content related items

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1572521575
+dateModified: 1572538461
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -3085,6 +3085,8 @@ matrixBlockTypes:
           columns:
             259:
               width: ''
+            265:
+              width: ''
             260:
               width: ''
             258:
@@ -5827,7 +5829,7 @@ superTableBlockTypes:
       9e3ed77a-cb3c-491b-b2ad-503715cbf99b:
         name: Entry
         handle: entry
-        instructions: 'Choose the entry to link to'
+        instructions: 'Choose the entry to link to. If you don''t choose one you must supply an External Link instead.'
         searchable: false
         translationMethod: site
         translationKeyFormat: null
@@ -5872,6 +5874,19 @@ superTableBlockTypes:
           columnType: text
         contentColumnType: text
         fieldGroup: null
+      b3ea3f1a-27d9-4c1e-b903-3ae96acc74b9:
+        name: 'External Link'
+        handle: externalLink
+        instructions: 'Optional – if you supply a link then this will be used instead of the entry. Use this to add a piece of content from an external, third-party website.'
+        searchable: false
+        translationMethod: site
+        translationKeyFormat: null
+        type: craft\fields\Url
+        settings:
+          placeholder: ''
+          maxLength: '255'
+        contentColumnType: string(255)
+        fieldGroup: null
     fieldLayouts:
       c352ef75-2b80-4c0e-8505-4164a11a4a65:
         tabs:
@@ -5881,14 +5896,17 @@ superTableBlockTypes:
             fields:
               2184906d-f2b9-4d39-a094-bfa50ccf8271:
                 required: false
-                sortOrder: 3
+                sortOrder: 4
               2dbee670-c961-4ea7-b503-cf23bce9541e:
                 required: false
-                sortOrder: 4
+                sortOrder: 5
               9e3ed77a-cb3c-491b-b2ad-503715cbf99b:
-                required: true
+                required: false
                 sortOrder: 1
               ab94c548-6f17-4790-b6dd-4c766143bee5:
+                required: false
+                sortOrder: 3
+              b3ea3f1a-27d9-4c1e-b903-3ae96acc74b9:
                 required: false
                 sortOrder: 2
   aba74ecd-5c81-4302-90e6-f7e62956af82:

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -214,16 +214,20 @@ class ContentHelpers
                         'heading' => $block->heading
                     ];
                     if (!empty($block->relatedItems->all())) {
-                        $gridBlocks = array_map(function ($gridBlock) use ($locale) {
+                        $gridBlocks = array_filter(array_map(function ($gridBlock) use ($locale) {
+                            $externalUrl = $gridBlock->externalLink;
                             $entry = $gridBlock->entry->one();
+                            if (!$entry && !$externalUrl) {
+                                return false;
+                            }
                             $entryBlock = [
                                 'title' => $gridBlock->entryTitle ? $gridBlock->entryTitle : $entry->title,
                                 'summary' => $gridBlock->entryDescription ?? null,
-                                'linkUrl' => EntryHelpers::uriForLocale($entry->uri, $locale),
+                                'linkUrl' => $externalUrl ? $externalUrl : EntryHelpers::uriForLocale($entry->uri, $locale),
                                 'trailImage' => $gridBlock->entryImage ? self::buildTrailImage($gridBlock->entryImage) : null,
                             ];
                             return $entryBlock;
-                        }, $block->relatedItems->all());
+                        }, $block->relatedItems->all()));
                     }
                     $data['content'] = $gridBlocks;
                     array_push($parts, $data);


### PR DESCRIPTION
By request from the Digital Comms team. The Flexible Content "related items" component currently only allows choosing an Entry to link to. This change allows it to link to an external item:

![image](https://user-images.githubusercontent.com/394376/67965303-bbefe380-fbf9-11e9-9c27-71a87e51e40b.png)

This means that it's now possible to create a related item which has neither a related Entry or an external link. The API code will strip these elements out, though.

No frontend change required to achieve this:

![image](https://user-images.githubusercontent.com/394376/67965367-d3c76780-fbf9-11e9-8a16-34cc1e7e9679.png)
