### PR TITLE
Optionally allow expired entries to be included when checking for translations

### DIFF
--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -29,7 +29,7 @@ class ContentHelpers
         ]) : null;
     }
 
-    public static function getCommonFields(Entry $entry, $status, $locale, $includeHeroes = true)
+    public static function getCommonFields(Entry $entry, $status, $locale, $includeHeroes = true, $includeExpiredForTranslations = false)
     {
         $fields = [
             'id' => $entry->id,
@@ -39,7 +39,7 @@ class ContentHelpers
             'postDate' => $entry->postDate,
             'dateCreated' => $entry->dateCreated,
             'dateUpdated' => $entry->dateUpdated,
-            'availableLanguages' => EntryHelpers::getAvailableLanguages($entry->id, $locale),
+            'availableLanguages' => EntryHelpers::getAvailableLanguages($entry->id, $locale, $includeExpiredForTranslations),
             'openGraph' => self::extractSocialMetaTags($entry),
             // @TODO: Is url used anywhere?
             'url' => $entry->url,

--- a/lib/EntryHelpers.php
+++ b/lib/EntryHelpers.php
@@ -12,13 +12,19 @@ class EntryHelpers
         return \Craft::t('site', $message, $variables, $locale);
     }
 
-    public static function getAvailableLanguages($entryId, $currentLanguage)
+    public static function getAvailableLanguages($entryId, $currentLanguage, $includeExpiredForTranslations = false)
     {
+        $statuses = ['live'];
         $alternateLanguage = $currentLanguage === 'en' ? 'cy' : 'en';
+
+        if ($includeExpiredForTranslations) {
+            $statuses[] = 'expired';
+        }
 
         $altEntry = Entry::find()
             ->id($entryId)
             ->site($alternateLanguage)
+            ->status($statuses)
             ->one();
 
         $availableLanguages = [$currentLanguage];

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -30,7 +30,7 @@ class FundingProgrammeTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale, $includeHeroes = $this->isSingle);
+        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale, $includeHeroes = $this->isSingle, $includeExpiredForTranslations = true);
 
         if ($entry->type->handle === 'contentPage') {
             return ContentHelpers::getFlexibleContentPage($entry, $this->locale);


### PR DESCRIPTION
We've had a question about [this programme page](https://www.tnlcommunityfund.org.uk/funding/programmes/coastal-communities-fund) which has a Welsh translation but doesn't offer a "Cymraeg" link (and vice-versa). 

The reason is that the API returns: `"availableLanguages": ["en"]` because the entry is expired (eg. the funding programme has closed). I've changed the code now to optionally allow an entry to be expired when checking for translations.

Currently we use expiry dates weirdly for funding programmes – eg. the content is still visible, we just use that date to determine when it closed. We should probably look at just adding a "Funding close date" field to these entries and doing it there instead, and allow expiry dates to do what they do everywhere else (eg. disable the content) to avoid these sort of workarounds.