### PR TITLE
Shrink in-body images to a maximum width 

### DIFF
--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -149,10 +149,21 @@ class ContentHelpers
         foreach ($entry->flexibleContent->all() as $block) {
             switch ($block->type->handle) {
                 case 'contentArea':
+
+                    // Scale down any in-body images
+                    $contentWithResizedImages = preg_replace_callback(
+                        '/<img src="(https:\/\/www.tnlcommunityfund.org.uk\/media\/.+?)"/i',
+                        function ($matches) {
+                            $url = Images::imgixUrl($matches[1], ['w' => 900, 'fit' => 'fill']);
+                            return '<img src="' . $url . '"';
+                        },
+                        $block->contentBody
+                    );
+
                     $data = [
                         'type' => $block->type->handle,
                         'title' => $block->flexTitle ?? null,
-                        'content' => $block->contentBody,
+                        'content' => $contentWithResizedImages,
                     ];
                     array_push($parts, $data);
                     break;


### PR DESCRIPTION
Some images, eg. the one midway through [this page](https://www.tnlcommunityfund.org.uk/about/the-national-lotterys-25th-birthday), are uploaded at high resolution and just duplicated in our output, eg. when used as in-body images in Redactor.

We should scale these down automatically but it's fiddly – Craft has image transforms but these have to be chosen when uploading images and it's not guaranteed people will remember. There's a neat-looking plugin called Retcon which allows "retrospective" HTML changes (eg. finding images from a Craft field and changing attributes etc) but it doesn't allow a direct swap like this change does.

Instead this code just looks for `<img>` elements pointing to our Media endpoint and swaps them with a more sensible Imgix URL. It probably needs a bit more kicking as I'm not certain it wouldn't do weird things to small images (scale them up?) or effect more heavily-styled inline images (media figures etc), though it's scoped only to `contentArea` flexible content blocks.

Suggestions welcome on other alternatives!
