### PR TITLE
Add insight child pages

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -227,6 +227,7 @@ function getResearch($locale, $type = false)
 
     $criteria = [
         'site' => $locale,
+        'level' => 1, // Skip child pages
         'section' => 'research',
         'status' => EntryHelpers::getVersionStatuses(),
         'type' => ($type === 'documents') ? 'researchDocument' : 'research'
@@ -368,7 +369,7 @@ function getResearch($locale, $type = false)
  * API Endpoint: Get research detail
  * Get full details of a single research entry
  */
-function getResearchDetail($locale, $slug)
+function getResearchDetail($locale, $slug, $childPageSlug = null)
 {
     normaliseCacheHeaders();
 
@@ -378,7 +379,7 @@ function getResearchDetail($locale, $slug)
         'criteria' => [
             'site' => $locale,
             'section' => 'research',
-            'slug' => $slug,
+            'slug' => $childPageSlug ? $childPageSlug : $slug,
             'status' => EntryHelpers::getVersionStatuses(),
         ],
         'one' => true,
@@ -734,6 +735,7 @@ return [
         'api/v1/<locale:en|cy>/research/<type:documents>' => getResearch,
         'api/v1/<locale:en|cy>/research' => getResearch,
         'api/v1/<locale:en|cy>/research/<slug>' => getResearchDetail,
+        'api/v1/<locale:en|cy>/research/<slug>/<childPageSlug:{slug}>' => getResearchDetail,
         'api/v1/<locale:en|cy>/strategic-programmes' => getStrategicProgrammes,
         'api/v1/<locale:en|cy>/strategic-programmes/<slug:{slug}>' => getStrategicProgramme,
         'api/v1/<locale:en|cy>/strategic-programmes/<slug:{slug}>/<childPageSlug:{slug}>' => getStrategicProgramme,

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1572539557
+dateModified: 1580815703
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -4283,7 +4283,25 @@ sections:
     type: single
     propagationMethod: all
   3102e285-face-4513-b17e-2d3b046fcc88:
+    name: Insights
+    handle: research
+    type: structure
     enableVersioning: true
+    propagationMethod: all
+    siteSettings:
+      81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
+        enabledByDefault: true
+        hasUrls: true
+        uriFormat: '{% if type.handle == ''research'' %}insights/{parent.slug}/{slug}{% else %}insights/documents/{slug}{% endif %}'
+        template: research/_entry
+      d0635f95-a563-4f66-9195-33da0eb644d5:
+        enabledByDefault: false
+        hasUrls: true
+        uriFormat: '{% if type.handle == ''research'' %}insights/{parent.slug}/{slug}{% else %}insights/documents/{slug}{% endif %}'
+        template: research/_entry
+    structure:
+      uid: 22f688e5-f1ba-4a56-8d90-8d86cf816043
+      maxLevels: null
     entryTypes:
       803ebe88-78a2-4e00-8b3c-a8649ffb61ce:
         fieldLayouts:
@@ -4381,21 +4399,6 @@ sections:
         sortOrder: 3
         titleFormat: ''
         titleLabel: Title
-    handle: research
-    name: Insights
-    siteSettings:
-      81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
-        enabledByDefault: true
-        hasUrls: true
-        template: research/_entry
-        uriFormat: '{% if type.handle == ''research'' %}insights/{slug}{% else %}insights/documents/{slug}{% endif %}'
-      d0635f95-a563-4f66-9195-33da0eb644d5:
-        enabledByDefault: false
-        hasUrls: true
-        template: research/_entry
-        uriFormat: '{% if type.handle == ''research'' %}insights/{slug}{% else %}insights/documents/{slug}{% endif %}'
-    type: channel
-    propagationMethod: all
   3ecf7fe6-7292-48f8-9a74-39c2ea37312f:
     enableVersioning: '1'
     entryTypes:

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1580815703
+dateModified: 1580899980
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -4301,7 +4301,7 @@ sections:
         template: research/_entry
     structure:
       uid: 22f688e5-f1ba-4a56-8d90-8d86cf816043
-      maxLevels: null
+      maxLevels: 1
     entryTypes:
       803ebe88-78a2-4e00-8b3c-a8649ffb61ce:
         fieldLayouts:

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -334,10 +334,8 @@ class ContentHelpers
     }
 
     // Returns a standardised form for flexible pages, typically children of other pages
-    public static function getFlexibleContentPage(Entry $entry, $locale)
+    public static function getParentInfo(Entry $entry, $locale)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-
         $parent = $entry->getParent();
         if ($parent) {
             $parent = [
@@ -345,6 +343,16 @@ class ContentHelpers
                 'linkUrl' => $parent->externalUrl ? $parent->externalUrl : EntryHelpers::uriForLocale($parent->uri, $locale),
             ];
         }
+        return $parent ?? null;
+    }
+
+
+    // Returns a standardised form for flexible pages, typically children of other pages
+    public static function getFlexibleContentPage(Entry $entry, $locale)
+    {
+        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
+
+        $parent = self::getParentInfo($entry, $locale);
         return array_merge(ContentHelpers::getCommonFields($entry, $status, $locale), [
             'content' => ContentHelpers::extractFlexibleContent($entry, $locale),
             'parent' => $parent ?? null

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -30,6 +30,8 @@ class ResearchTransformer extends TransformerAbstract
             'thumbnail' => self::buildTrailImage(Images::extractImage($entry->heroImage)),
             'trailImage' => self::buildTrailImage(Images::extractNewHeroImageField($entry->hero)),
 
+            'parent' => ContentHelpers::getParentInfo($entry, $this->locale),
+
             'introduction' => $entry->introductionText ?? null,
             'contactEmail' => $researchMeta ? $researchMeta->contactEmail : null,
             'researchPartners' => $researchMeta ? $researchMeta->researchPartners : null,


### PR DESCRIPTION
Allow Insights pages to have children. Pairs with https://github.com/biglotteryfund/blf-alpha/pull/2914

The biggest change here is converting the section from a Channel to a Structure. This doesn't seem to have broken anything, I guess you risk losing data when going the other way (eg. structural data around ordering/ancestors etc) but this should be safer?

Otherwise this follows the same pattern as the other sections we've given child pages to.