### PR TITLE
Fix for PHP 7.2+ countable

### DIFF
--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -134,7 +134,7 @@ class ContentHelpers
      * - Inline figure (image with a caption)
      * - Media aside (callout block with text, image, and link)
      */
-    public static function extractFlexibleContent(Entry $entry, $locale, $children = null)
+    public static function extractFlexibleContent(Entry $entry, $locale, $children = array())
     {
         $parts = [];
         if (!$entry->flexibleContent) {


### PR DESCRIPTION
Updated default null to be empty array to work on PHP 7.2+ as this version added an incompatible change which cause null to no longer be considered a countable. 

Incompatible changes can be found here: https://www.php.net/manual/en/migration72.incompatible.php 