### PR TITLE
Allow Strategic Programme Related Content to be blank

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1585834006
+dateModified: 1586175330
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -1171,13 +1171,20 @@ fields:
                 -
                   - width
                   - ''
+          -
+            - 1886c75e-22fc-4f85-aabf-58913f9b3515
+            -
+              __assoc__:
+                -
+                  - width
+                  - ''
       contentTable: '{{%stc_strategicprogrammelatestcontent}}'
       fieldLayout: row
       maxRows: '1'
-      minRows: '1'
+      minRows: ''
       propagationMethod: all
       selectionLabel: ''
-      staticField: '1'
+      staticField: ''
     translationKeyFormat: null
     translationMethod: site
     type: verbb\supertable\fields\SuperTableField


### PR DESCRIPTION
A CMS user reported an issue where a page with this field couldn't be saved as it was required. Technically the field wasn't required, but its sub-fields (it's a Super Table field) _were_ required.

The culprit was this setting: 

<img width="324" alt="image" src="https://user-images.githubusercontent.com/394376/78557735-3821cf00-7809-11ea-9b20-22a7185b53c0.png">

It meant that there was a fixed display of 1 row for every section with this field. I've switched it off and now it's optional again.