### PR TITLE
Removed redundant 'themecolour' field.

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1586179755
+dateModified: 1586264679
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -880,62 +880,6 @@ fields:
     translationKeyFormat: null
     translationMethod: site
     type: craft\fields\Entries
-  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-    contentColumnType: string
-    fieldGroup: 381bc7ef-8175-4392-a114-07f68c9a1b9a
-    handle: themeColour
-    instructions: 'Colour to use as an accent colour for the page'
-    name: 'Theme Colour'
-    searchable: '1'
-    settings:
-      options:
-        -
-          __assoc__:
-            -
-              - default
-              - '1'
-            -
-              - label
-              - Pink
-            -
-              - value
-              - pink
-        -
-          __assoc__:
-            -
-              - default
-              - ''
-            -
-              - label
-              - Blue
-            -
-              - value
-              - blue
-        -
-          __assoc__:
-            -
-              - default
-              - ''
-            -
-              - label
-              - Cyan
-            -
-              - value
-              - cyan
-        -
-          __assoc__:
-            -
-              - default
-              - ''
-            -
-              - label
-              - Turquoise
-            -
-              - value
-              - turquoise
-    translationKeyFormat: null
-    translationMethod: none
-    type: craft\fields\Dropdown
   7d911d3c-651d-4c2c-ae62-a64b0f554bb0:
     contentColumnType: text
     fieldGroup: 9a6de417-cda1-486f-9022-b8c5387f751e
@@ -4873,9 +4817,6 @@ sections:
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: false
                     sortOrder: 4
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
                 name: 'Content Page'
                 sortOrder: 1
               -
@@ -4937,9 +4878,6 @@ sections:
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: true
                     sortOrder: 6
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 5
                   ccd71b86-6564-429f-972a-1def8e6840a4:
                     required: false
                     sortOrder: 2
@@ -5118,9 +5056,6 @@ sections:
                   40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
                     required: true
                     sortOrder: 4
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
                 name: About
                 sortOrder: 1
               -
@@ -5228,9 +5163,6 @@ sections:
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: true
                     sortOrder: 4
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
                 name: Content
                 sortOrder: 1
               -
@@ -5289,9 +5221,6 @@ sections:
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: true
                     sortOrder: 4
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: true
-                    sortOrder: 3
                 name: 'Content Page'
                 sortOrder: 1
               -
@@ -5347,9 +5276,6 @@ sections:
                   2bef64b2-1bcc-462c-b819-97a7df3fb33a:
                     required: '0'
                     sortOrder: '4'
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: '0'
-                    sortOrder: '3'
                 name: 'Link item'
                 sortOrder: '1'
         handle: linkItem
@@ -5376,9 +5302,6 @@ sections:
                   7552a2c7-9bf0-408b-91a2-1a6570b3d78a:
                     required: true
                     sortOrder: 4
-                  7c09fc37-6348-4112-b5e1-f4e32fe2c4ec:
-                    required: false
-                    sortOrder: 3
                 name: 'Content Page'
                 sortOrder: 1
               -


### PR DESCRIPTION
Removed the theme colour field that was used in a few sections. Didn't appear to be referenced anywhere in the web code and so was safely removed and checked by loading the sections on the website against the live version.