### PR TITLE
Removed all instances of getDraftorVersionEntry

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -455,7 +455,7 @@ function getPublication($locale, $programmeSlug, $pageSlug = null)
         'criteria' => $criteria,
         'meta' => $meta ?? null,
         'transformer' => function (Entry $entry) use ($locale) {
-            $common = ContentHelpers::getCommonFields($entry, $entry->status, $locale);
+            $common = ContentHelpers::getCommonFields($entry, $locale);
             return array_merge($common, [
                 'tags' => ContentHelpers::getTags($entry->tags->all(), $locale),
                 'authors' => ContentHelpers::getTags($entry->authors->all(), $locale),
@@ -606,7 +606,7 @@ function getFlexibleContent($locale)
             'section' => ['aboutLandingPage'],
         ],
         'transformer' => function (Entry $entry) use ($locale) {
-            $common = ContentHelpers::getCommonFields($entry, $entry->status, $locale);
+            $common = ContentHelpers::getCommonFields($entry, $locale);
             return array_merge($common, [
                 'flexibleContent' => ContentHelpers::extractFlexibleContent($entry, $locale),
             ]);
@@ -756,7 +756,7 @@ function getDataPage($locale)
         'transformer' => function (Entry $entry) use ($locale) {
             $regionStats = $entry->regionStats->one();
 
-            $common = ContentHelpers::getCommonFields($entry, $entry->status, $locale);
+            $common = ContentHelpers::getCommonFields($entry, $locale);
             return array_merge($common, [
                 'regions' => [
                     'england' => array_map(function ($row) {

--- a/config/element-api.php
+++ b/config/element-api.php
@@ -455,8 +455,7 @@ function getPublication($locale, $programmeSlug, $pageSlug = null)
         'criteria' => $criteria,
         'meta' => $meta ?? null,
         'transformer' => function (Entry $entry) use ($locale) {
-            list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-            $common = ContentHelpers::getCommonFields($entry, $status, $locale);
+            $common = ContentHelpers::getCommonFields($entry, $entry->status, $locale);
             return array_merge($common, [
                 'tags' => ContentHelpers::getTags($entry->tags->all(), $locale),
                 'authors' => ContentHelpers::getTags($entry->authors->all(), $locale),
@@ -607,8 +606,7 @@ function getFlexibleContent($locale)
             'section' => ['aboutLandingPage'],
         ],
         'transformer' => function (Entry $entry) use ($locale) {
-            list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-            $common = ContentHelpers::getCommonFields($entry, $status, $locale);
+            $common = ContentHelpers::getCommonFields($entry, $entry->status, $locale);
             return array_merge($common, [
                 'flexibleContent' => ContentHelpers::extractFlexibleContent($entry, $locale),
             ]);
@@ -756,14 +754,9 @@ function getDataPage($locale)
         ],
         'one' => true,
         'transformer' => function (Entry $entry) use ($locale) {
-            list(
-                'entry' => $entry,
-                'status' => $status
-            ) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-
             $regionStats = $entry->regionStats->one();
 
-            $common = ContentHelpers::getCommonFields($entry, $status, $locale);
+            $common = ContentHelpers::getCommonFields($entry, $entry->status, $locale);
             return array_merge($common, [
                 'regions' => [
                     'england' => array_map(function ($row) {

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -348,10 +348,8 @@ class ContentHelpers
     // Returns a standardised form for flexible pages, typically children of other pages
     public static function getFlexibleContentPage(Entry $entry, $locale)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-
         $parent = self::getParentInfo($entry, $locale);
-        return array_merge(ContentHelpers::getCommonFields($entry, $status, $locale), [
+        return array_merge(ContentHelpers::getCommonFields($entry, $entry->status, $locale), [
             'content' => ContentHelpers::extractFlexibleContent($entry, $locale),
             'parent' => $parent ?? null
         ]);

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -29,13 +29,13 @@ class ContentHelpers
         ]) : null;
     }
 
-    public static function getCommonFields(Entry $entry, $status, $locale, $includeHeroes = true, $includeExpiredForTranslations = false)
+    public static function getCommonFields(Entry $entry, $locale, $includeHeroes = true, $includeExpiredForTranslations = false)
     {
         $fields = [
             'id' => $entry->id,
             'entryType' => $entry->type->handle,
             'slug' => $entry->slug,
-            'status' => $status,
+            'status' => $entry->status,
             'postDate' => $entry->postDate,
             'dateCreated' => $entry->dateCreated,
             'dateUpdated' => $entry->dateUpdated,
@@ -349,7 +349,7 @@ class ContentHelpers
     public static function getFlexibleContentPage(Entry $entry, $locale)
     {
         $parent = self::getParentInfo($entry, $locale);
-        return array_merge(ContentHelpers::getCommonFields($entry, $entry->status, $locale), [
+        return array_merge(ContentHelpers::getCommonFields($entry, $locale), [
             'content' => ContentHelpers::extractFlexibleContent($entry, $locale),
             'parent' => $parent ?? null
         ]);

--- a/lib/EntryHelpers.php
+++ b/lib/EntryHelpers.php
@@ -50,65 +50,6 @@ class EntryHelpers
         return $isDraft || $isVersion;
     }
 
-    /**
-     * getDraftOrVersionOfEntry
-     * Looks up an old version or draft of an entry
-     * @usage: `list('entry' => $entry, 'status' => $status) = getDraftOrVersionOfEntry($entry);`
-     */
-    public static function getDraftOrVersionOfEntry(Entry $entry)
-    {
-        $isDraft = \Craft::$app->request->getParam('draft');
-        $isVersion = \Craft::$app->request->getParam('version');
-
-        if ($isDraft) {
-            $status = 'draft';
-            $revisionId = $isDraft;
-            $revisionMethod = 'getDraftsByEntryId';
-            $entryRevisionMethod = 'getDraftById';
-            $revisionIdParam = 'draftId';
-        } else if ($isVersion) {
-            $status = 'version';
-            $revisionId = $isVersion;
-            $revisionMethod = 'getVersionsByEntryId';
-            $entryRevisionMethod = 'getVersionById';
-            $revisionIdParam = 'versionId';
-        }
-
-        if (($isDraft || $isVersion) && $revisionId) {
-
-            // Get all drafts/revisions of this post
-            $revisions = \Craft::$app->entryRevisions->{$revisionMethod}($entry->id, $entry->siteId);
-
-            // Filter drafts/revisions for the requested ID
-            $revisions = array_filter($revisions, function ($revision) use ($revisionId, $revisionIdParam, $entryRevisionMethod) {
-                return $revision->{$revisionIdParam} == $revisionId;
-            });
-
-            // Is this draft/revision ID valid for this post?
-            if (count($revisions) > 0) {
-
-                // Look up the revision itself
-                $revision = \Craft::$app->entryRevisions->{$entryRevisionMethod}($revisionId);
-
-                if ($revision) {
-                    // Non-live content has a null URI in Craft,
-                    // so restore it to its base entry's URI
-                    $revision->uri = $entry->uri;
-                    return [
-                        'entry' => $revision,
-                        'status' => $status,
-                    ];
-                }
-            }
-        }
-
-        // default to the original, unmodified entry
-        return [
-            'entry' => $entry,
-            'status' => $entry->status,
-        ];
-    }
-
     public static function getVersionStatuses()
     {
         /**

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -29,8 +29,7 @@ class FundingProgrammeTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale, $includeHeroes = $this->isSingle, $includeExpiredForTranslations = true);
+        $commonFields = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale, $includeHeroes = $this->isSingle, $includeExpiredForTranslations = true);
 
         if ($entry->type->handle === 'contentPage') {
             return ContentHelpers::getFlexibleContentPage($entry, $this->locale);

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -29,7 +29,7 @@ class FundingProgrammeTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        $commonFields = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale, $includeHeroes = $this->isSingle, $includeExpiredForTranslations = true);
+        $commonFields = ContentHelpers::getCommonFields($entry, $this->locale, $includeHeroes = $this->isSingle, $includeExpiredForTranslations = true);
 
         if ($entry->type->handle === 'contentPage') {
             return ContentHelpers::getFlexibleContentPage($entry, $this->locale);

--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -42,8 +42,7 @@ class ListingTransformer extends TransformerAbstract
         $relatedEntries = [];
 
         foreach ($relatedSearch as $relatedEntry) {
-            list('entry' => $relatedEntry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($relatedEntry);
-            $commonFields = ContentHelpers::getCommonFields($relatedEntry, $status, $this->locale);
+            $commonFields = ContentHelpers::getCommonFields($relatedEntry, $entry->status, $this->locale);
 
             /**
              * Custom link URL
@@ -73,8 +72,7 @@ class ListingTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
 
         $customFields = [
             'introduction' => $entry->introductionText ?? null,

--- a/lib/Listing.php
+++ b/lib/Listing.php
@@ -42,7 +42,7 @@ class ListingTransformer extends TransformerAbstract
         $relatedEntries = [];
 
         foreach ($relatedSearch as $relatedEntry) {
-            $commonFields = ContentHelpers::getCommonFields($relatedEntry, $entry->status, $this->locale);
+            $commonFields = ContentHelpers::getCommonFields($relatedEntry, $this->locale);
 
             /**
              * Custom link URL
@@ -72,7 +72,7 @@ class ListingTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        $commonFields = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $this->locale);
 
         $customFields = [
             'introduction' => $entry->introductionText ?? null,

--- a/lib/People.php
+++ b/lib/People.php
@@ -15,7 +15,7 @@ class PeopleTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        $common = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
+        $common = ContentHelpers::getCommonFields($entry, $this->locale);
 
         return array_merge($common, [
             'people' => array_map(function ($person) {

--- a/lib/People.php
+++ b/lib/People.php
@@ -15,8 +15,7 @@ class PeopleTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $common = ContentHelpers::getCommonFields($entry, $status, $this->locale);
+        $common = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
 
         return array_merge($common, [
             'people' => array_map(function ($person) {

--- a/lib/ProjectStories.php
+++ b/lib/ProjectStories.php
@@ -30,7 +30,7 @@ class ProjectStoriesTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        $common = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
+        $common = ContentHelpers::getCommonFields($entry, $this->locale);
 
         return array_merge($common, [
             // @TODO: Move trailSummary and trailPhoto to getCommonFields?

--- a/lib/ProjectStories.php
+++ b/lib/ProjectStories.php
@@ -30,8 +30,7 @@ class ProjectStoriesTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $common = ContentHelpers::getCommonFields($entry, $status, $this->locale);
+        $common = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
 
         return array_merge($common, [
             // @TODO: Move trailSummary and trailPhoto to getCommonFields?

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -24,7 +24,7 @@ class ResearchTransformer extends TransformerAbstract
     public function transform(Entry $entry)
     {
         $researchMeta = $entry->researchMeta->one();
-        return array_merge(ContentHelpers::getCommonFields($entry, $entry->status, $this->locale), [
+        return array_merge(ContentHelpers::getCommonFields($entry, $this->locale), [
             'trailImage' => self::buildTrailImage(Images::extractHeroImageField($entry->hero)),
 
             'parent' => ContentHelpers::getParentInfo($entry, $this->locale),

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -23,9 +23,8 @@ class ResearchTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
         $researchMeta = $entry->researchMeta->one();
-        return array_merge(ContentHelpers::getCommonFields($entry, $status, $this->locale), [
+        return array_merge(ContentHelpers::getCommonFields($entry, $entry->status, $this->locale), [
             'trailImage' => self::buildTrailImage(Images::extractHeroImageField($entry->hero)),
 
             'parent' => ContentHelpers::getParentInfo($entry, $this->locale),

--- a/lib/ResearchDocument.php
+++ b/lib/ResearchDocument.php
@@ -15,8 +15,6 @@ class ResearchDocumentTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-
         $asset = !empty($entry->document) ? $entry->document->one() : null;
         $documentData = $asset ? [
             'url' => $asset->url,
@@ -33,7 +31,7 @@ class ResearchDocumentTransformer extends TransformerAbstract
             ];
         }
 
-        return array_merge(ContentHelpers::getCommonFields($entry, $status, $this->locale), [
+        return array_merge(ContentHelpers::getCommonFields($entry, $entry->status, $this->locale), [
             'summary' => $entry->summary,
             'relatedFundingProgrammes' => array_map(function ($programme) {
                 return [

--- a/lib/ResearchDocument.php
+++ b/lib/ResearchDocument.php
@@ -31,7 +31,7 @@ class ResearchDocumentTransformer extends TransformerAbstract
             ];
         }
 
-        return array_merge(ContentHelpers::getCommonFields($entry, $entry->status, $this->locale), [
+        return array_merge(ContentHelpers::getCommonFields($entry, $this->locale), [
             'summary' => $entry->summary,
             'relatedFundingProgrammes' => array_map(function ($programme) {
                 return [

--- a/lib/StrategicProgrammes.php
+++ b/lib/StrategicProgrammes.php
@@ -24,8 +24,7 @@ class StrategicProgrammeTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
 
         if ($entry->type->handle === 'contentPage') {
             return ContentHelpers::getFlexibleContentPage($entry, $this->locale);

--- a/lib/StrategicProgrammes.php
+++ b/lib/StrategicProgrammes.php
@@ -24,7 +24,7 @@ class StrategicProgrammeTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        $commonFields = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $this->locale);
 
         if ($entry->type->handle === 'contentPage') {
             return ContentHelpers::getFlexibleContentPage($entry, $this->locale);

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -15,8 +15,7 @@ class UpdatesTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        list('entry' => $entry, 'status' => $status) = EntryHelpers::getDraftOrVersionOfEntry($entry);
-        $commonFields = ContentHelpers::getCommonFields($entry, $status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
         $primaryCategory = $entry->category ? $entry->category->inReverse()->one() : null;
 
         $trailPhotoUrl = $entry->trailPhoto->one() ? $entry->trailPhoto->one()->url : null;

--- a/lib/Updates.php
+++ b/lib/Updates.php
@@ -15,7 +15,7 @@ class UpdatesTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        $commonFields = ContentHelpers::getCommonFields($entry, $entry->status, $this->locale);
+        $commonFields = ContentHelpers::getCommonFields($entry, $this->locale);
         $primaryCategory = $entry->category ? $entry->category->inReverse()->one() : null;
 
         $trailPhotoUrl = $entry->trailPhoto->one() ? $entry->trailPhoto->one()->url : null;


### PR DESCRIPTION
Removed all instances of getDraftorVersionEntry. The list is no longer created and so $status is directly pulled from $entry->status.

Therefore the getDraftorVersionEntry function has been removed as it is no longer being used.