### PR TITLE
Add Covid-19 funding info

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1588769190
+dateModified: 1588770804
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -531,6 +531,24 @@ fields:
       charLimit: ''
       code: ''
       columnType: text
+      initialRows: '4'
+      multiline: ''
+      placeholder: ''
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\PlainText
+  444ab41c-0362-40f3-9e62-08136a307eef:
+    contentColumnType: string(1200)
+    fieldGroup: 9a6de417-cda1-486f-9022-b8c5387f751e
+    handle: programmeTrailText
+    instructions: 'Sum up this programme in a couple of lines. Displayed around the site as a short trail for the funding programme. Keep it brief.'
+    name: 'Programme Trail Text'
+    searchable: true
+    settings:
+      byteLimit: null
+      charLimit: 300
+      code: ''
+      columnType: null
       initialRows: '4'
       multiline: ''
       placeholder: ''
@@ -4287,53 +4305,56 @@ sections:
                 fields:
                   03ed24af-07b1-42c3-875e-98050e9560c7:
                     required: false
-                    sortOrder: 6
+                    sortOrder: 4
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
-                    sortOrder: 3
+                    sortOrder: 1
                   7234b38a-a7fc-4fbb-840f-c277d57f1ced:
                     required: false
-                    sortOrder: 7
+                    sortOrder: 5
                   bcbf9339-ab42-4e3f-9db7-eaf3b499d36c:
                     required: false
-                    sortOrder: 5
+                    sortOrder: 3
                   e212ef59-b2d5-4fc4-9f7a-ca51a236b8bb:
                     required: false
-                    sortOrder: 4
+                    sortOrder: 2
                 name: 'Programme Details'
                 sortOrder: 1
               -
                 fields:
                   0db131ea-69e3-4c13-955d-b607df3c9959:
                     required: false
-                    sortOrder: 5
+                    sortOrder: 6
                   1338f3a8-bad4-4e23-a0f0-327be8f16e60:
                     required: false
-                    sortOrder: 9
+                    sortOrder: 10
+                  444ab41c-0362-40f3-9e62-08136a307eef:
+                    required: false
+                    sortOrder: 2
                   5899dcd7-1384-49e0-98a5-633b44fa05c0:
                     required: false
                     sortOrder: 1
                   650ff388-625b-4f42-82bd-10a96d6b47b1:
                     required: false
-                    sortOrder: 3
+                    sortOrder: 4
                   8d3adb13-80ec-4b1a-9524-7b23bafb6c60:
                     required: false
-                    sortOrder: 6
+                    sortOrder: 7
                   9af6d5eb-9e64-473d-b1c3-5642ec2ead05:
                     required: false
-                    sortOrder: 8
+                    sortOrder: 9
                   b1cb76e6-64d2-41f8-837d-089907b480c6:
                     required: false
-                    sortOrder: 2
+                    sortOrder: 3
                   c2f8265a-898e-4f67-abf9-45dabc783f7e:
                     required: false
-                    sortOrder: 7
+                    sortOrder: 8
                   e5147d7e-c0d3-4cb2-92cf-3b5e5eae96e6:
                     required: false
                     sortOrder: 11
                   ee5ad666-8266-45cc-9852-f681a7db300f:
                     required: false
-                    sortOrder: 4
+                    sortOrder: 5
                 name: 'Programme Summary'
                 sortOrder: 2
               -

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1588344344
+dateModified: 1588769190
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -433,6 +433,21 @@ fields:
       localizeBlocks: '1'
       maxBlocks: ''
       minBlocks: '1'
+    translationKeyFormat: null
+    translationMethod: site
+    type: craft\fields\Matrix
+  3aab45b3-a045-4267-a7b3-429e9a48266c:
+    contentColumnType: string
+    fieldGroup: 381bc7ef-8175-4392-a114-07f68c9a1b9a
+    handle: covid19Status
+    instructions: 'Enter some text to describe a country''s funding status with regard to Covid-19'
+    name: 'Covid-19 Status'
+    searchable: true
+    settings:
+      contentTable: '{{%matrixcontent_covid19status}}'
+      maxBlocks: ''
+      minBlocks: ''
+      propagationMethod: all
     translationKeyFormat: null
     translationMethod: site
     type: craft\fields\Matrix
@@ -1746,6 +1761,20 @@ fields:
     translationKeyFormat: null
     translationMethod: none
     type: craft\fields\PlainText
+globalSets:
+  7ffe4884-bd5d-4d9d-9409-b33683df032b:
+    fieldLayouts:
+      36364aea-ab29-4bea-b676-1c737bb12e34:
+        tabs:
+          -
+            fields:
+              3aab45b3-a045-4267-a7b3-429e9a48266c:
+                required: false
+                sortOrder: 1
+            name: Status
+            sortOrder: 1
+    handle: covid19Messaging
+    name: 'Covid-19 Messaging'
 graphql:
   schemas:
     1ebb8d2f-c0a7-4086-9b28-e1ea24ce64b6:
@@ -2999,6 +3028,111 @@ matrixBlockTypes:
     handle: relatedContent
     name: 'Related Content'
     sortOrder: 7
+  b21b7945-0fa0-41d5-97d7-cb290892b259:
+    field: 3aab45b3-a045-4267-a7b3-429e9a48266c
+    fieldLayouts:
+      9f5c9ef5-40cc-42a0-84c3-d42355223061:
+        tabs:
+          -
+            fields:
+              d74420bd-5580-4ffc-84d4-957fc73f757a:
+                required: true
+                sortOrder: 2
+              f19a371f-b0b9-4431-be2b-de822c693382:
+                required: true
+                sortOrder: 1
+            name: Content
+            sortOrder: 1
+    fields:
+      d74420bd-5580-4ffc-84d4-957fc73f757a:
+        contentColumnType: text
+        fieldGroup: null
+        handle: statusMessage
+        instructions: 'What is this country''s funding status?'
+        name: 'Status message'
+        searchable: true
+        settings:
+          byteLimit: null
+          charLimit: null
+          code: ''
+          columnType: null
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      f19a371f-b0b9-4431-be2b-de822c693382:
+        contentColumnType: string
+        fieldGroup: null
+        handle: country
+        instructions: 'The country this response is for'
+        name: Country
+        searchable: false
+        settings:
+          optgroups: true
+          options:
+            -
+              __assoc__:
+                -
+                  - label
+                  - England
+                -
+                  - value
+                  - england
+                -
+                  - default
+                  - ''
+            -
+              __assoc__:
+                -
+                  - label
+                  - 'Northern Ireland'
+                -
+                  - value
+                  - northernIreland
+                -
+                  - default
+                  - ''
+            -
+              __assoc__:
+                -
+                  - label
+                  - Scotland
+                -
+                  - value
+                  - scotland
+                -
+                  - default
+                  - ''
+            -
+              __assoc__:
+                -
+                  - label
+                  - Wales
+                -
+                  - value
+                  - wales
+                -
+                  - default
+                  - ''
+            -
+              __assoc__:
+                -
+                  - label
+                  - UK-wide
+                -
+                  - value
+                  - ukWide
+                -
+                  - default
+                  - ''
+        translationKeyFormat: null
+        translationMethod: none
+        type: craft\fields\Dropdown
+    handle: covidStatus
+    name: 'Covid Status'
+    sortOrder: 1
   b3eca5c5-5a5f-4000-bc2f-005c98db960f:
     field: 40755bc8-380a-49b7-9f5b-786c5e1e6bbe
     fieldLayouts:

--- a/lib/FundingProgrammes.php
+++ b/lib/FundingProgrammes.php
@@ -37,6 +37,7 @@ class FundingProgrammeTransformer extends TransformerAbstract
             $commonProgrammeFields = [
                 'isArchived' => $commonFields['status'] === 'expired' && $entry->legacyPath !== null,
                 'description' => $entry->programmeIntro ?? null,
+                'trailText' => $entry->programmeTrailText ?? null,
                 'area' => $entry->programmeArea ? [
                     'label' => EntryHelpers::translate($this->locale, $entry->programmeArea->label),
                     'value' => $entry->programmeArea->value,


### PR DESCRIPTION
This pairs with [the frontend changes here](https://github.com/biglotteryfund/blf-alpha/pull/3310) and adds two things:

- A global set for C19 statuses by country:

![image](https://user-images.githubusercontent.com/394376/81182005-287edd00-8fa5-11ea-81c7-d904d7cadd44.png)

(thought this was a nice opportunity to try these out for something that we'd otherwise have to hardcode in the app, and will likely change/evolve frequently)

- A new 'trail text' field for funding programmes:

![image](https://user-images.githubusercontent.com/394376/81182075-43e9e800-8fa5-11ea-86d3-4a1ea59b3039.png)

(This is limited to 300 characters to avoid the possibility of anyone dumping tons of text in at a future date 😎)