### PR TITLE
Add CMS formatting styles

### DIFF
--- a/config/redactor/Full.json
+++ b/config/redactor/Full.json
@@ -1,6 +1,52 @@
 {
     "buttons": ["html", "formatting", "bold", "italic", "unorderedlist", "orderedlist", "link", "image", "video", "file"],
     "formatting": ["p", "blockquote", "h2", "h3", "h4", "h5"],
+    "formattingAdd": {
+        "phone-number": {
+            "title": "Phone number",
+            "api": "module.block.format",
+            "args": {
+                "tag": "p",
+                "attr": {
+                    "class": "cms-icon-phone-number"
+                },
+                "type": "toggle"
+            }
+        },
+        "email-address": {
+            "title": "Email address",
+            "api": "module.block.format",
+            "args": {
+                "tag": "p",
+                "attr": {
+                    "class": "cms-icon-email-address"
+                },
+                "type": "toggle"
+            }
+        },
+        "location-map": {
+            "title": "Location / Map",
+            "api": "module.block.format",
+            "args": {
+                "tag": "p",
+                "attr": {
+                    "class": "cms-icon-location-map"
+                },
+                "type": "toggle"
+            }
+        },
+        "fax-number": {
+            "title": "Fax number",
+            "api": "module.block.format",
+            "args": {
+                "tag": "p",
+                "attr": {
+                    "class": "cms-icon-fax-number"
+                },
+                "type": "toggle"
+            }
+        }
+    },
     "plugins": ["fullscreen", "video", "table", "linkButton"],
     "imagePosition" : {
         "left": "image-left",

--- a/config/redactor/plugins/linkButton.js
+++ b/config/redactor/plugins/linkButton.js
@@ -18,6 +18,8 @@
             if (element.nodeName === 'A') {
                 var $node = $R.dom(element);
                 $node.toggleClass('btn');
+            } else {
+                alert("Please select a link first before making it into a button.")
             }
         }
     });

--- a/web/resources/css/cp.css
+++ b/web/resources/css/cp.css
@@ -19,3 +19,44 @@
 .redactor-styles figure.image-centre img {
     margin: auto;
 }
+
+/* Phone icon */
+.redactor-dropdown-item-phone-number span::before,
+.redactor-styles .cms-icon-phone-number::before,
+/* Email icon */
+.redactor-dropdown-item-email-address span::before,
+.redactor-styles .cms-icon-email-address::before,
+/* Map icon */
+.redactor-dropdown-item-location-map span::before,
+.redactor-styles .cms-icon-location-map::before,
+/* Fax icon(?!) */
+.redactor-dropdown-item-fax-number span::before,
+.redactor-styles .cms-icon-fax-number::before {
+    content: '';
+    width: 10px;
+    height: 10px;
+    display: inline-block;
+    margin-right: 7px;
+}
+
+
+.redactor-dropdown-item-phone-number span::before,
+.redactor-styles .cms-icon-phone-number::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 384'%3E%3Cpath d='M353.188 252.052c-23.51 0-46.594-3.677-68.469-10.906-10.719-3.656-23.896-.302-30.438 6.417l-43.177 32.594c-50.073-26.729-80.917-57.563-107.281-107.26l31.635-42.052c8.219-8.208 11.167-20.198 7.635-31.448-7.26-21.99-10.948-45.063-10.948-68.583C132.146 13.823 118.323 0 101.333 0h-70.52C13.823 0 0 13.823 0 30.813 0 225.563 158.438 384 353.188 384c16.99 0 30.813-13.823 30.813-30.813v-70.323c-.001-16.989-13.824-30.812-30.813-30.812z'/%3E%3C/svg%3E");
+}
+
+
+.redactor-dropdown-item-email-address span::before,
+.redactor-styles .cms-icon-email-address::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 477.867 477.867'%3E%3Cpath d='M460.8 68.267H17.067C7.641 68.267 0 75.908 0 85.333v307.2c0 9.426 7.641 17.067 17.067 17.067H460.8c9.426 0 17.067-7.641 17.067-17.067v-307.2c0-9.425-7.641-17.066-17.067-17.066zM432.811 102.4L238.933 251.529 45.056 102.4h387.755zm10.922 273.067h-409.6V137.062L228.54 286.6a17.065 17.065 0 0020.787 0l194.406-149.538v238.405z'/%3E%3C/svg%3E");
+}
+
+.redactor-dropdown-item-location-map span::before,
+.redactor-styles .cms-icon-location-map::before {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath d='M256 0C161.896 0 85.333 76.563 85.333 170.667c0 28.25 7.063 56.26 20.49 81.104L246.667 506.5c1.875 3.396 5.448 5.5 9.333 5.5s7.458-2.104 9.333-5.5l140.896-254.813c13.375-24.76 20.438-52.771 20.438-81.021C426.667 76.563 350.104 0 256 0zm0 256c-47.052 0-85.333-38.281-85.333-85.333S208.948 85.334 256 85.334s85.333 38.281 85.333 85.333S303.052 256 256 256z'/%3E%3C/svg%3E");
+}
+
+.redactor-dropdown-item-fax-number span::before,
+.redactor-styles .cms-icon-fax-number::before {
+
+}

--- a/web/resources/css/cp.css
+++ b/web/resources/css/cp.css
@@ -33,10 +33,12 @@
 .redactor-dropdown-item-fax-number span::before,
 .redactor-styles .cms-icon-fax-number::before {
     content: '';
-    width: 10px;
-    height: 10px;
+    width: 15px;
+    height: 15px;
     display: inline-block;
     margin-right: 7px;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
 }
 
 
@@ -58,5 +60,5 @@
 
 .redactor-dropdown-item-fax-number span::before,
 .redactor-styles .cms-icon-fax-number::before {
-
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 90 35'%3E%3Cpath d='M5.78 15.18h12v4.45H5.73v15.25H-.22l.05-35h20.35l.1 4.35H5.78v10.95zM44.78 22.63H32.53l-4.6 12.25h-6.05l14-35h6.9l12.85 35h-6.6l-4.25-12.25zm-10.7-4.4h9.2l-4.4-12.75-4.8 12.75zM82.58 34.88l-8.85-13.15-9.25 13.15h-6.55l12.6-17.8-11.6-17.2h7.1l8.2 12.2 8.55-12.2h6.6l-12 16.9 12.2 18.1h-7z'/%3E%3C/svg%3E");
 }


### PR DESCRIPTION
Adds some new formatting styles to help control the [impending new design for the Contact page](https://github.com/biglotteryfund/blf-alpha/issues/2500):

![image](https://user-images.githubusercontent.com/394376/84038453-df50ed00-a997-11ea-9ca1-4c84e9300779.png)

(still awaiting a fax icon!)

Has some corresponding frontend changes to style these classes.