### PR TITLE
Add new Person type to Flexible Content

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -521,6 +521,7 @@ function getResearchDetail($locale, $slug, $childPageSlug = null)
         'criteria' => [
             'site' => $locale,
             'section' => 'research',
+            'type' => 'research',
             'slug' => $childPageSlug ? $childPageSlug : $slug,
             'status' => EntryHelpers::getVersionStatuses(),
         ],

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1591624698
+dateModified: 1591628955
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -2615,7 +2615,7 @@ matrixBlockTypes:
         type: craft\fields\PlainText
     handle: automaticContentList
     name: 'Automatic Content List'
-    sortOrder: 8
+    sortOrder: 9
   62705224-8e25-453a-bce2-7d8e0533abce:
     field: 065e680b-ad85-42eb-a1b2-6623e8233466
     fieldLayouts:
@@ -3045,7 +3045,7 @@ matrixBlockTypes:
         type: craft\fields\PlainText
     handle: relatedContent
     name: 'Related Content'
-    sortOrder: 7
+    sortOrder: 8
   b21b7945-0fa0-41d5-97d7-cb290892b259:
     field: 3aab45b3-a045-4267-a7b3-429e9a48266c
     fieldLayouts:
@@ -3261,7 +3261,7 @@ matrixBlockTypes:
         type: craft\fields\PlainText
     handle: gridBlocks
     name: 'Grid Blocks'
-    sortOrder: 6
+    sortOrder: 7
   cdf38474-7e76-4140-aecb-1e2962f2a9b7:
     field: 6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51
     fieldLayouts:
@@ -3609,6 +3609,140 @@ matrixBlockTypes:
     handle: inlineFigure
     name: Photo
     sortOrder: 2
+  d2b597d3-efb9-433d-bb43-5cb2c219ab12:
+    field: 40755bc8-380a-49b7-9f5b-786c5e1e6bbe
+    fieldLayouts:
+      07b0c8cb-2dd8-428d-96d7-ee156a065a60:
+        tabs:
+          -
+            fields:
+              0311af81-729c-4001-9c3e-73bd492f9084:
+                required: true
+                sortOrder: 5
+              0f219149-7f97-4cca-a923-6a13c5324028:
+                required: false
+                sortOrder: 3
+              9c8e239f-4126-4f5f-ab91-5740a5a64b34:
+                required: false
+                sortOrder: 2
+              b5469ec4-1495-419a-b68a-8ed4b8c3f133:
+                required: true
+                sortOrder: 1
+              e5b09713-810e-466c-b433-8ae80f9c2ee2:
+                required: false
+                sortOrder: 4
+            name: Content
+            sortOrder: 1
+    fields:
+      0311af81-729c-4001-9c3e-73bd492f9084:
+        contentColumnType: text
+        fieldGroup: null
+        handle: personBio
+        instructions: 'Add some text about this person to appear alongside their photo'
+        name: Biography
+        searchable: true
+        settings:
+          availableTransforms: '*'
+          availableVolumes: '*'
+          cleanupHtml: true
+          columnType: text
+          purifierConfig: safe-iframe-media.json
+          purifyHtml: '1'
+          redactorConfig: Full.json
+          removeEmptyTags: '1'
+          removeInlineStyles: '1'
+          removeNbsp: '1'
+          showUnpermittedFiles: false
+          showUnpermittedVolumes: false
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\redactor\Field
+      0f219149-7f97-4cca-a923-6a13c5324028:
+        contentColumnType: text
+        fieldGroup: null
+        handle: personRole
+        instructions: 'Enter this person''s job title, eg. "CEO", "Designer", etc.'
+        name: Role
+        searchable: true
+        settings:
+          byteLimit: null
+          charLimit: null
+          code: ''
+          columnType: null
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      9c8e239f-4126-4f5f-ab91-5740a5a64b34:
+        contentColumnType: text
+        fieldGroup: null
+        handle: tocTitle
+        instructions: 'If you''re using a Table of Contents block for this page, the text you enter here will appear in the table instead of the title above.'
+        name: 'Table of Contents title'
+        searchable: true
+        settings:
+          byteLimit: null
+          charLimit: null
+          code: ''
+          columnType: null
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      b5469ec4-1495-419a-b68a-8ed4b8c3f133:
+        contentColumnType: text
+        fieldGroup: null
+        handle: flexTitle
+        instructions: 'A title field to distinguish this block of content - the name of this individual'
+        name: 'Person''s name'
+        searchable: true
+        settings:
+          byteLimit: null
+          charLimit: null
+          code: ''
+          columnType: null
+          initialRows: '4'
+          multiline: ''
+          placeholder: ''
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\PlainText
+      e5b09713-810e-466c-b433-8ae80f9c2ee2:
+        contentColumnType: string
+        fieldGroup: null
+        handle: personPhoto
+        instructions: 'Upload a picture of this person'
+        name: Photo
+        searchable: true
+        settings:
+          allowedKinds:
+            - image
+          defaultUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          defaultUploadLocationSubpath: ''
+          limit: '1'
+          localizeRelations: ''
+          restrictFiles: '1'
+          selectionLabel: 'Add a photo'
+          showUnpermittedFiles: false
+          showUnpermittedVolumes: false
+          singleUploadLocationSource: 'volume:0516f25e-8c65-48c1-9c7a-f94a6a954edf'
+          singleUploadLocationSubpath: profiles
+          source: null
+          sources: '*'
+          targetSiteId: null
+          useSingleFolder: true
+          validateRelatedElements: ''
+          viewMode: list
+        translationKeyFormat: null
+        translationMethod: site
+        type: craft\fields\Assets
+    handle: person
+    name: Person
+    sortOrder: 6
   d399fe59-317e-4880-a801-2f3f8b2764f6:
     field: 8c779db5-d5b9-4669-bb16-7749b921bc9b
     fieldLayouts:
@@ -3920,7 +4054,7 @@ matrixBlockTypes:
         type: craft\fields\Lightswitch
     handle: tableOfContents
     name: 'Table of Contents'
-    sortOrder: 9
+    sortOrder: 10
   f76c4d99-f62f-463b-b573-946becc0923d:
     field: 40755bc8-380a-49b7-9f5b-786c5e1e6bbe
     fieldLayouts:
@@ -3971,7 +4105,7 @@ matrixBlockTypes:
         type: craft\fields\Dropdown
     handle: childPageList
     name: 'Child Page List'
-    sortOrder: 10
+    sortOrder: 11
   fa1bc12d-a0f6-4d83-a213-cb9a9ca82eb5:
     field: e2c780b8-c133-4e69-af2f-cee1076275cd
     fieldLayouts:
@@ -5026,10 +5160,13 @@ sections:
                 fields:
                   1620ec3b-4d1d-4929-bd17-68cf9f224a53:
                     required: false
-                    sortOrder: 2
+                    sortOrder: 1
+                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
+                    required: false
+                    sortOrder: 3
                   8c779db5-d5b9-4669-bb16-7749b921bc9b:
                     required: true
-                    sortOrder: 3
+                    sortOrder: 2
                 name: People
                 sortOrder: 1
               -
@@ -5925,7 +6062,6 @@ superTableBlockTypes:
             - 'section:a1f1765e-10d1-45ef-905e-1a8cf5a6458e'
             - 'section:07ef3333-69c2-456d-ba88-3e0e60c091b8'
             - 'section:b50d445d-1022-48a7-898a-ff03d8304412'
-            - 'section:6924a426-e1bd-4c6e-96e4-513956cbaa44'
             - 'section:2b1f6da1-20e9-4176-a181-7ab073fab8f9'
             - 'section:3102e285-face-4513-b17e-2d3b046fcc88'
             - 'section:73426a06-bcdf-471b-9984-9fe28d7e5606'

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1591879441
+dateModified: 1591963253
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'

--- a/lib/ContentHelpers.php
+++ b/lib/ContentHelpers.php
@@ -204,6 +204,23 @@ class ContentHelpers
                     }
                     $data['content'] = $factRiver;
                     break;
+                case 'person':
+                    $image = $block->personPhoto->one() ?? null;
+                    $data = [
+                        'name' => $block->flexTitle,
+                        'role' => $block->personRole ?? null,
+                        'image' => $image ? [
+                            // Is the source image large or small?
+                            // Used to determine what layout to use
+                            'type' => $image->width > 500 ? 'large' : 'small',
+                            'url' => Images::imgixUrl(
+                                $image->url,
+                                ['fit' => 'crop', 'crop' => 'entropy', 'max-w' => 1200]
+                            ),
+                        ] : null,
+                        'bio' => $block->personBio,
+                    ];
+                    break;
                 case 'relatedContent':
                     $relatedContent = array();
                     if (!empty($block->relatedItems->all())) {


### PR DESCRIPTION
Add a new flex content block to allow migration of the [Our People](https://github.com/biglotteryfund/blf-alpha/issues/3366) section.

![image](https://user-images.githubusercontent.com/394376/84665722-15521c00-af18-11ea-8e19-1d2f1fba88a9.png)

This means that we can deprecate the old structure and move these pages directly into the About section.

There's also a change in here to enable showing "sibling" pages in a sidebar, eg:

![image](https://user-images.githubusercontent.com/394376/84665886-47637e00-af18-11ea-9973-03b05962f627.png)

The logic was already there for this but it didn't work correctly for top-level pages which didn't have parents. The change here makes this work for parentless pages.

Pairs with https://github.com/biglotteryfund/blf-alpha/pull/3458