### PR TITLE
Fix document query search bug

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -225,15 +225,20 @@ function getResearch($locale, $type = false)
         'type' => ($type === 'documents') ? 'researchDocument' : 'research'
     ];
 
-    $sortParam = \Craft::$app->request->getParam('sort');
     $searchQuery = \Craft::$app->request->getParam('q');
-    if ($searchQuery && ($sortParam === 'score' || !$sortParam)) {
-        $criteria['orderBy'] = 'score';
+
+    if ($searchQuery) {
         $criteria['search'] = [
             'query' => $searchQuery,
             'subLeft' => true,
             'subRight' => true,
         ];
+    }
+
+    $sortParam = \Craft::$app->request->getParam('sort');
+
+    if ($searchQuery && ($sortParam === 'score' || !$sortParam)) {
+        $criteria['orderBy'] = 'score';
     } else if ($sortParam === 'newest') {
         $criteria['orderBy'] = 'postDate desc';
     } else if ($sortParam === 'oldest') {
@@ -380,15 +385,20 @@ function getPublication($locale, $programmeSlug, $pageSlug = null)
 
     $associatedProgramme = Entry::find()->section(['fundingProgrammes', 'strategicProgrammes'])->status(['live', 'expired'])->slug($programmeSlug)->site($locale)->one();
 
-    $sortParam = \Craft::$app->request->getParam('sort');
     $searchQuery = \Craft::$app->request->getParam('q');
-    if ($searchQuery && ($sortParam === 'score' || !$sortParam)) {
-        $criteria['orderBy'] = 'score';
+
+    if ($searchQuery) {
         $criteria['search'] = [
             'query' => $searchQuery,
             'subLeft' => true,
             'subRight' => true,
         ];
+    }
+
+    $sortParam = \Craft::$app->request->getParam('sort');
+
+    if ($searchQuery && ($sortParam === 'score' || !$sortParam)) {
+        $criteria['orderBy'] = 'score';
     } else if ($sortParam === 'newest') {
         $criteria['orderBy'] = 'postDate desc';
     } else if ($sortParam === 'oldest') {


### PR DESCRIPTION
Spotted this earlier:

1. Visit the Publication Search and enter [a query like "baby"](https://www.tnlcommunityfund.org.uk/funding/publications/a-better-start?q=baby)
2. Note the number of results – 17
3. [Re-order the search results by date](https://www.tnlcommunityfund.org.uk/funding/publications/a-better-start?q=baby&sort=newest) – now there are 49 results!?

This is due to a silly error in the search code which only uses the `q=baby` parameter when the `sort` type is `score` or not specified. This change separates out that logic from the search criteria code.

(the same bug is present on [the Insights Documents search](https://www.tnlcommunityfund.org.uk/insights/documents?q=HeadStart), which the Publication Search code is based on, so I've fixed it there too).