### PR TITLE
Allow Insights section to have a new 'Content Page' entry type

### DIFF
--- a/config/element-api.php
+++ b/config/element-api.php
@@ -512,7 +512,7 @@ function getResearchDetail($locale, $slug, $childPageSlug = null)
         'criteria' => [
             'site' => $locale,
             'section' => 'research',
-            'type' => 'research',
+            'type' => ['research', 'contentPage'],
             'slug' => $childPageSlug ? $childPageSlug : $slug,
             'status' => EntryHelpers::getVersionStatuses(),
         ],

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -44,7 +44,7 @@ categoryGroups:
     structure:
       maxLevels: '1'
       uid: a0dbb9d0-734d-4e43-a0d5-56e09ff07075
-dateModified: 1595943981
+dateModified: 1596451010
 email:
   fromEmail: noreply@blf.digital
   fromName: 'The National Lottery Community Fund Digital'
@@ -4419,6 +4419,33 @@ sections:
   3102e285-face-4513-b17e-2d3b046fcc88:
     enableVersioning: true
     entryTypes:
+      43576092-2e5d-42f2-8efb-45f256d352b2:
+        fieldLayouts:
+          adf6caaa-e95d-447d-a527-107d3d3392b4:
+            tabs:
+              -
+                fields:
+                  1620ec3b-4d1d-4929-bd17-68cf9f224a53:
+                    required: false
+                    sortOrder: 1
+                  40755bc8-380a-49b7-9f5b-786c5e1e6bbe:
+                    required: true
+                    sortOrder: 2
+                name: Content
+                sortOrder: 1
+              -
+                fields:
+                  6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
+                    required: false
+                    sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
+        handle: contentPage
+        hasTitleField: true
+        name: 'Content Page'
+        sortOrder: 4
+        titleFormat: ''
+        titleLabel: Title
       803ebe88-78a2-4e00-8b3c-a8649ffb61ce:
         fieldLayouts:
           148090b7-1887-40f5-a00e-8d90a513eb77:
@@ -4516,20 +4543,28 @@ sections:
     name: Insights
     previewTargets:
       -
-        label: 'Primary entry page'
-        urlFormat: '{url}'
+        __assoc__:
+          -
+            - label
+            - 'Primary entry page'
+          -
+            - urlFormat
+            - '{url}'
+          -
+            - refresh
+            - '1'
     propagationMethod: all
     siteSettings:
       81de1ac6-1a0b-40e6-b99c-42b99e5dc777:
         enabledByDefault: true
         hasUrls: true
         template: research/_entry
-        uriFormat: '{% if type.handle == ''research'' %}insights/{parent.slug}/{slug}{% else %}insights/documents/{slug}{% endif %}'
+        uriFormat: '{% if type.handle == ''researchDocument'' %}insights/documents/{slug}{% else %}insights/{parent.slug}/{slug}{% endif %}'
       d0635f95-a563-4f66-9195-33da0eb644d5:
         enabledByDefault: false
         hasUrls: true
         template: research/_entry
-        uriFormat: '{% if type.handle == ''research'' %}insights/{parent.slug}/{slug}{% else %}insights/documents/{slug}{% endif %}'
+        uriFormat: '{% if type.handle == ''researchDocument'' %}insights/documents/{slug}{% else %}insights/{parent.slug}/{slug}{% endif %}'
     structure:
       maxLevels: 2
       uid: 22f688e5-f1ba-4a56-8d90-8d86cf816043
@@ -5430,6 +5465,13 @@ sections:
                     sortOrder: 2
                 name: 'Content Page'
                 sortOrder: 1
+              -
+                fields:
+                  6a3270e2-2cb8-4aac-9fa6-72b5ccf0ef51:
+                    required: false
+                    sortOrder: 1
+                name: 'Social Media'
+                sortOrder: 2
         handle: contentPage
         hasTitleField: true
         name: 'Content Page'

--- a/lib/Research.php
+++ b/lib/Research.php
@@ -23,65 +23,69 @@ class ResearchTransformer extends TransformerAbstract
 
     public function transform(Entry $entry)
     {
-        $researchMeta = $entry->researchMeta->one();
-        return array_merge(ContentHelpers::getCommonFields($entry, $this->locale), [
-            'trailImage' => self::buildTrailImage(Images::extractHeroImageField($entry->hero)),
+        if ($entry->type->handle === 'contentPage') {
+            return ContentHelpers::getFlexibleContentPage($entry, $this->locale);
+        } else {
+            $researchMeta = $entry->researchMeta->one();
+            return array_merge(ContentHelpers::getCommonFields($entry, $this->locale), [
+                'trailImage' => self::buildTrailImage(Images::extractHeroImageField($entry->hero)),
 
-            'parent' => ContentHelpers::getParentInfo($entry, $this->locale),
+                'parent' => ContentHelpers::getParentInfo($entry, $this->locale),
 
-            'introduction' => $entry->introductionText ?? null,
-            'contactEmail' => $researchMeta ? $researchMeta->contactEmail : null,
-            'researchPartners' => $researchMeta ? $researchMeta->researchPartners : null,
+                'introduction' => $entry->introductionText ?? null,
+                'contactEmail' => $researchMeta ? $researchMeta->contactEmail : null,
+                'researchPartners' => $researchMeta ? $researchMeta->researchPartners : null,
 
-            'documentsPrefix' => $entry->researchDocumentsPrefix ?? null,
-            'documents' => array_map(function ($document) {
-                $asset = $document->documentAsset->one();
-                return [
-                    'title' => $document->documentTitle,
-                    'url' => $asset->url,
-                    'filetype' => $asset->extension,
-                    'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0),
-                    'contents' => $document->documentContents ? explode("\n", $document->documentContents) : [],
-                ];
-            }, $entry->researchDocuments->all() ?? []),
+                'documentsPrefix' => $entry->researchDocumentsPrefix ?? null,
+                'documents' => array_map(function ($document) {
+                    $asset = $document->documentAsset->one();
+                    return [
+                        'title' => $document->documentTitle,
+                        'url' => $asset->url,
+                        'filetype' => $asset->extension,
+                        'filesize' => StringHelpers::formatBytes($asset->size, $precision = 0),
+                        'contents' => $document->documentContents ? explode("\n", $document->documentContents) : [],
+                    ];
+                }, $entry->researchDocuments->all() ?? []),
 
-            'relatedFundingProgrammes' => array_map(function ($programme) {
-                return [
-                    'title' => $programme->title,
-                    'linkUrl' => $programme->externalUrl ? $programme->externalUrl : EntryHelpers::uriForLocale($programme->uri, $this->locale),
-                ];
-            }, $entry->relatedFundingProgrammes->status(['live', 'expired'])->all() ?? []),
+                'relatedFundingProgrammes' => array_map(function ($programme) {
+                    return [
+                        'title' => $programme->title,
+                        'linkUrl' => $programme->externalUrl ? $programme->externalUrl : EntryHelpers::uriForLocale($programme->uri, $this->locale),
+                    ];
+                }, $entry->relatedFundingProgrammes->status(['live', 'expired'])->all() ?? []),
 
-            'sectionsPrefix' => $entry->researchSectionsPrefix ?? null,
-            'sections' => array_map(function ($row) {
-                return [
-                    'title' => $row->sectionTitle,
-                    'prefix' => $row->sectionPrefix ?? null,
-                    'parts' => array_map(function ($block) {
-                        switch ($block->type->handle) {
-                            case 'contentArea':
-                                return [
-                                    'type' => $block->type->handle,
-                                    'title' => $block->contentTitle,
-                                    'content' => $block->contentBody,
-                                ];
-                                break;
-                            case 'callout':
-                                return [
-                                    'type' => $block->type->handle,
-                                    'content' => $block->calloutContent,
-                                    'credit' => $block->calloutCredit ?? null,
-                                    'isQuote' => $block->isQuote,
-                                ];
-                                break;
-                        }
-                    }, $row->contentSections->all() ?? [])
-                ];
-            }, $entry->researchSections->all() ?? []),
+                'sectionsPrefix' => $entry->researchSectionsPrefix ?? null,
+                'sections' => array_map(function ($row) {
+                    return [
+                        'title' => $row->sectionTitle,
+                        'prefix' => $row->sectionPrefix ?? null,
+                        'parts' => array_map(function ($block) {
+                            switch ($block->type->handle) {
+                                case 'contentArea':
+                                    return [
+                                        'type' => $block->type->handle,
+                                        'title' => $block->contentTitle,
+                                        'content' => $block->contentBody,
+                                    ];
+                                    break;
+                                case 'callout':
+                                    return [
+                                        'type' => $block->type->handle,
+                                        'content' => $block->calloutContent,
+                                        'credit' => $block->calloutCredit ?? null,
+                                        'isQuote' => $block->isQuote,
+                                    ];
+                                    break;
+                            }
+                        }, $row->contentSections->all() ?? [])
+                    ];
+                }, $entry->researchSections->all() ?? []),
 
-            'meta' => [
-                'searchScore' => $entry->searchScore ?? null,
-            ],
-        ]);
+                'meta' => [
+                    'searchScore' => $entry->searchScore ?? null,
+                ],
+            ]);
+        }
     }
 }


### PR DESCRIPTION
Quick change by request of the Knowledge & Learning team – they want to be able to create flexible content pages in their Insights section, rather than just the existing type which is fairly templated (eg. [like this](https://www.tnlcommunityfund.org.uk/insights/building-resilience)). 

We already use this `contentPage` pattern in a few other sections so this was simple enough to add here.

Pairs with https://github.com/biglotteryfund/blf-alpha/pull/3608