### PR TITLE
Undo/redo buttons added to redactor toolbars

### DIFF
--- a/config/redactor/Basics.json
+++ b/config/redactor/Basics.json
@@ -1,5 +1,5 @@
 {
-    "buttons": ["formatting", "bold", "italic", "unorderedlist", "orderedlist", "link"],
+    "buttons": ["formatting", "redo", "undo", "bold", "italic", "unorderedlist", "orderedlist", "link"],
     "formatting": ["p", "h2", "h3", "h4", "h5"],
     "plugins": ["fullscreen"]
 }

--- a/config/redactor/Full.json
+++ b/config/redactor/Full.json
@@ -1,5 +1,5 @@
 {
-    "buttons": ["html", "formatting", "bold", "italic", "unorderedlist", "orderedlist", "link", "redactoranchors", "image", "video", "file"],
+    "buttons": ["html", "redo", "undo", "formatting", "bold", "italic", "unorderedlist", "orderedlist", "link", "redactoranchors", "image", "video", "file"],
     "formatting": ["p", "blockquote", "h2", "h3", "h4", "h5"],
     "formattingAdd": {
         "small-text": {

--- a/config/redactor/Minimal.json
+++ b/config/redactor/Minimal.json
@@ -1,3 +1,3 @@
 {
-	"buttons": ["bold", "italic"]
+	"buttons": ["redo", "undo", "bold", "italic"]
 }


### PR DESCRIPTION
All redactor toolbars now have an undo and a redo button added on them now for editors to use