### PR TITLE
Title translates for each site 

### DIFF
--- a/config/project/entryTypes/grantmakingPractice--34dc3ee3-72ff-4906-a9df-4b2b94c9ad15.yaml
+++ b/config/project/entryTypes/grantmakingPractice--34dc3ee3-72ff-4906-a9df-4b2b94c9ad15.yaml
@@ -75,4 +75,4 @@ section: 4526ec29-66b7-476d-92ca-712a962b38e8
 sortOrder: 1
 titleFormat: null
 titleTranslationKeyFormat: null
-titleTranslationMethod: none
+titleTranslationMethod: site


### PR DESCRIPTION
Fix for a problem when users updated the title in welsh on the grantmaking practice section - it would update the title on the english version of the page as well and vice versa