### PR TITLE
Potential fix for AWS build failure.

### DIFF
--- a/craft
+++ b/craft
@@ -18,7 +18,7 @@ if (file_exists($root.'/.env')) {
 
 // Craft
 define('CRAFT_BASE_PATH', $root);
-define('CRAFT_ENVIRONMENT', $_ENV['CRAFT_ENVIRONMENT'] ?: 'production');
+define('CRAFT_ENVIRONMENT', env('CRAFT_ENVIRONMENT') ?: 'production');
 $app = require $root.'/vendor/craftcms/cms/bootstrap/console.php';
 $exitCode = $app->run();
 exit($exitCode);


### PR DESCRIPTION
AWS build fails after updates due to index issue. This may resolve the problem.