### PR TITLE
Removing italics button as per web-87

### DIFF
--- a/config/redactor/Basics.json
+++ b/config/redactor/Basics.json
@@ -1,5 +1,5 @@
 {
-    "buttons": ["formatting", "redo", "undo", "bold", "italic", "unorderedlist", "orderedlist", "link"],
+    "buttons": ["formatting", "redo", "undo", "bold", "unorderedlist", "orderedlist", "link"],
     "formatting": ["p", "h2", "h3", "h4", "h5"],
     "plugins": ["fullscreen"]
 }

--- a/config/redactor/Full.json
+++ b/config/redactor/Full.json
@@ -1,5 +1,5 @@
 {
-    "buttons": ["html", "redo", "undo", "formatting", "bold", "italic", "unorderedlist", "orderedlist", "link", "redactoranchors", "image", "video", "file"],
+    "buttons": ["html", "redo", "undo", "formatting", "bold", "unorderedlist", "orderedlist", "link", "redactoranchors", "image", "video", "file"],
     "formatting": ["p", "blockquote", "h2", "h3", "h4", "h5"],
     "formattingAdd": {
         "small-text": {

--- a/config/redactor/Minimal.json
+++ b/config/redactor/Minimal.json
@@ -1,3 +1,3 @@
 {
-	"buttons": ["redo", "undo", "bold", "italic"]
+	"buttons": ["redo", "undo", "bold"]
 }


### PR DESCRIPTION
removed "italics" option from all button lists in the redactor json files. tested and doing so removes the button from the editors. 