### PR TITLE
WEB-97 Updated default image crop

### DIFF
--- a/lib/Images.php
+++ b/lib/Images.php
@@ -35,7 +35,7 @@ class Images
             $builder->setSignKey($imgixConfig['signKey']);
             $builder->setIncludeLibraryParam(false);
 
-            $defaults = array('auto' => "compress,format", 'crop' => 'entropy', 'fit' => 'crop');
+            $defaults = array('auto' => "compress,format", 'crop' => 'faces,edge', 'fit' => 'crop');
             $params = array_replace_recursive($defaults, $options);
             return $builder->createURL($parsedUri->getPath(), $params);
         } else {

--- a/tests/ImagesTest.php
+++ b/tests/ImagesTest.php
@@ -9,7 +9,7 @@ final class ImagesTest extends TestCase
     public function testBuildsImgixUrl(): void
     {
         $this->assertRegExp(
-            '/image\.jpg\?auto=compress%2Cformat&crop=entropy&fit=crop&s=.*$/',
+            '/image\.jpg\?auto=compress%2Cformat&crop=faces%2Cedge&fit=crop&s=.*$/',
             Images::imgixUrl("https://media.example.com/path/to/image.jpg")
         );
 

--- a/tests/ImagesTest.php
+++ b/tests/ImagesTest.php
@@ -14,7 +14,7 @@ final class ImagesTest extends TestCase
         );
 
         $this->assertRegExp(
-            '/image\.jpg\?auto=compress%2Cformat&crop=entropy&fit=crop&w=100&s=.*$/',
+            '/image\.jpg\?auto=compress%2Cformat&crop=faces%2Cedge&fit=crop&w=100&s=.*$/',
             Images::imgixUrl("https://media.example.com/path/to/image.jpg", ['w' => 100])
         );
     }


### PR DESCRIPTION
Image cropping was previously using just entropy by default, updated to use faces then edge detection to improve smaller size images. 